### PR TITLE
Use intermediate env var for Pulumi passphrase

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,8 @@ jobs:
           credentials_json: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT_KEY }}
 
       - name: Deploy to Production
+        env:
+          PULUMI_PASSPHRASE: ${{ secrets.PULUMI_PROD_PASSPHRASE }}
         run: |
-          echo "${{ secrets.PULUMI_PROD_PASSPHRASE }}" > passphrase.prod.txt
+          echo "$PULUMI_PASSPHRASE" > passphrase.prod.txt
           make up


### PR DESCRIPTION
Addresses the security concern where secrets were directly interpolated in GitHub Actions run commands.

Following [GitHub's security best practices](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable), the secret is now passed through an intermediate environment variable (`PULUMI_PASSPHRASE`) before being written to the file.

This approach:
- Fixes the security issue with direct secret interpolation
- Maintains compatibility with existing local development workflows (developers can continue using `passphrase.prod.txt` locally)
- Keeps the Makefile unchanged, unlike PR #1

The key improvement is that `${{ secrets.X }}` is no longer expanded directly in the run command, reducing the risk of accidental disclosure if GitHub's masking fails or is bypassed.