### PR TITLE
Add evalstate and cliffhall to docs-maintaners

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -71,7 +71,7 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'cliffhall',
-    memberOf: ['moderators'],
+    memberOf: ['docs-maintaners', 'moderators'],
   },
   {
     github: 'crondinini-ant',
@@ -105,7 +105,7 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'evalstate',
-    memberOf: ['moderators'],
+    memberOf: ['docs-maintaners', 'moderators'],
   },
   {
     github: 'fabpot',


### PR DESCRIPTION
## Summary
- Add @evalstate to docs-maintaners team
- Add @cliffhall to docs-maintaners team

Both users are already moderators and are now being added to the docs-maintaners team to help maintain documentation.

## Test plan
- [ ] Verify Pulumi changes apply successfully
- [ ] Confirm GitHub team memberships are updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)