### PR TITLE
Add inspector maintainer group

### DIFF
--- a/src/config/groups.ts
+++ b/src/config/groups.ts
@@ -39,6 +39,12 @@ export const GROUPS = defineGroups([
     memberOf: ['steering-committee'],
     onlyOnPlatforms: ['github'],
   },
+  {
+    name: 'inspector-maintainers',
+    description: 'MCP Inspector maintainers',
+    memberOf: ['steering-committee'],
+    onlyOnPlatforms: ['github'],
+  },
 
   // SDK Maintainers
   {

--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -85,11 +85,11 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     users: [
       { username: 'richardkmichael', permission: 'triage' },
       { username: 'jspahrsummers', permission: 'admin' },
-      { username: 'olaservo', permission: 'push' },
       { username: 'an-dustin', permission: 'admin' },
       { username: 'ashwin-ant', permission: 'admin' },
     ],
     teams: [
+      { team: 'inspector-maintainers', permission: 'push' },
       { team: 'auth-wg', permission: 'push' },
       { team: 'core', permission: 'maintain' },
       { team: 'core-maintainers', permission: 'push' },

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -71,7 +71,7 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'cliffhall',
-    memberOf: ['docs-maintaners', 'moderators'],
+    memberOf: ['docs-maintaners', 'inspector-maintainers', 'moderators'],
   },
   {
     github: 'crondinini-ant',
@@ -157,6 +157,10 @@ export const MEMBERS: readonly Member[] = [
     memberOf: ['core-maintainers'],
   },
   {
+    github: 'KKonstantinov',
+    memberOf: ['inspector-maintainers'],
+  },
+  {
     github: 'koic',
     memberOf: ['ruby-sdk'],
   },
@@ -214,7 +218,7 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'olaservo',
-    memberOf: ['docs-maintaners', 'moderators'],
+    memberOf: ['docs-maintaners', 'inspector-maintainers', 'moderators'],
   },
   {
     github: 'pcarleton',


### PR DESCRIPTION
- Reconfigures explicit access to push to inspector repo using a group
- Adds KKonstantinov

## Motivation and Context

Push access was being granted to existing maintainers either by individuals being added (olaservo) or through a different group like `moderators` (cliffhall).  This setup should make it map more directly to who is in that group, vs added from other groups.

See also: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1672

## How Has This Been Tested?

Will test once live by attempting to merge a PR.

## Breaking Changes

None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

I'm keeping all the existing individuals added as overrides to keep this set of changes smaller, but we might want to revisit the way other users are configured here as well.
