### PR TITLE
Add MCPB maintainers group

### DIFF
--- a/src/config/groups.ts
+++ b/src/config/groups.ts
@@ -45,6 +45,12 @@ export const GROUPS = defineGroups([
     memberOf: ['steering-committee'],
     onlyOnPlatforms: ['github'],
   },
+  {
+    name: 'mcpb-maintainers',
+    description: 'MCPB (Model Context Protocol Bundle) maintainers',
+    memberOf: ['steering-committee'],
+    onlyOnPlatforms: ['github'],
+  },
 
   // SDK Maintainers
   {

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -46,6 +46,10 @@ export const MEMBERS: readonly Member[] = [
     memberOf: ['go-sdk'],
   },
   {
+    github: 'asklar',
+    memberOf: ['mcpb-maintainers'],
+  },
+  {
     github: 'atesgoral',
     memberOf: ['ruby-sdk'],
   },
@@ -88,7 +92,7 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'domdomegg',
     email: 'adam@modelcontextprotocol.io',
-    memberOf: ['core', 'registry-wg'],
+    memberOf: ['core', 'mcpb-maintainers', 'registry-wg'],
   },
   {
     github: 'dsp-ant',
@@ -146,6 +150,10 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'jerome3o-anthropic',
     memberOf: ['core', 'moderators'],
+  },
+  {
+    github: 'joan-anthropic',
+    memberOf: ['mcpb-maintainers'],
   },
   {
     github: 'jonathanhefner',


### PR DESCRIPTION
Creates a new mcpb-maintainers team under the steering committee with initial maintainers:
- Joan Xie (joan-anthropic)
- Adam Jones (domdomegg) 
- Alex Sklar (asklar)

This supports the proposal to move MCPB into the modelcontextprotocol org.