### PR TITLE
Add security-advisories team as organization security managers

### DIFF
--- a/src/config/groups.ts
+++ b/src/config/groups.ts
@@ -151,6 +151,12 @@ export const GROUPS = defineGroups([
     onlyOnPlatforms: ['github'],
   },
   {
+    name: 'security-advisories',
+    description: 'Security advisory managers (can add collaborators to advisories)',
+    memberOf: ['security-wg'],
+    onlyOnPlatforms: ['github'],
+  },
+  {
     name: 'transport-wg',
     description: 'Transport Working Group',
     memberOf: ['working-groups'],

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -149,7 +149,7 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'jenn-newton',
-    memberOf: ['security-wg'],
+    memberOf: ['security-advisories'],
   },
   {
     github: 'jerome3o-anthropic',

--- a/src/github.ts
+++ b/src/github.ts
@@ -43,3 +43,10 @@ REPOSITORY_ACCESS.forEach((repo) => {
     })),
   });
 });
+
+// Assign security-advisories team as organization security managers
+// This grants members the ability to view security alerts and manage security
+// settings across all repos, including adding collaborators to security advisories
+new github.OrganizationSecurityManager('security-managers', {
+  teamSlug: 'security-advisories',
+});


### PR DESCRIPTION
## Summary

- Creates a new `security-advisories` team (child of `security-wg`) for managing security advisory collaborators
- Assigns the team as organization security managers via Pulumi `OrganizationSecurityManager` resource
- Adds @jenn-newton to the `security-advisories` team

## Details

The GitHub [security manager role](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/managing-security-managers-in-your-organization) grants:
- Read access on all repositories in the organization
- Write access on all security alerts  
- Ability to configure security feature settings at org and repo level
- **Ability to add collaborators to repository security advisories**

## Test plan

- [ ] Review Pulumi preview output after merge
- [ ] Verify @jenn-newton can add collaborators to security advisories

🤖 Generated with [Claude Code](https://claude.com/claude-code)