### PR TITLE
Add a-akimov to docs-maintaners, tighten inspector/servers permissions

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -87,10 +87,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'auth-wg', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'push' },
-      { team: 'docs-maintaners', permission: 'push' },
       { team: 'go-sdk', permission: 'push' },
-      { team: 'ig-financial-services', permission: 'push' },
-      { team: 'interest-groups', permission: 'push' },
       { team: 'java-sdk', permission: 'push' },
       { team: 'kotlin-sdk', permission: 'push' },
       { team: 'moderators', permission: 'push' },
@@ -107,7 +104,6 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'transport-wg', permission: 'push' },
       { team: 'typescript-sdk', permission: 'push' },
       { team: 'typescript-sdk-auth', permission: 'push' },
-      { team: 'working-groups', permission: 'push' },
     ],
   },
   {
@@ -142,10 +138,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: 'quickstart-resources',
-    users: [
-      { username: 'jspahrsummers', permission: 'admin' },
-      { username: 'a-akimov', permission: 'push' },
-    ],
+    users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
       { team: 'auth-wg', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
@@ -185,8 +178,6 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'docs-maintaners', permission: 'push' },
       { team: 'go-sdk', permission: 'push' },
-      { team: 'ig-financial-services', permission: 'push' },
-      { team: 'interest-groups', permission: 'push' },
       { team: 'java-sdk', permission: 'push' },
       { team: 'kotlin-sdk', permission: 'push' },
       { team: 'moderators', permission: 'push' },
@@ -203,7 +194,6 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'transport-wg', permission: 'push' },
       { team: 'typescript-sdk', permission: 'push' },
       { team: 'typescript-sdk-auth', permission: 'push' },
-      { team: 'working-groups', permission: 'push' },
     ],
   },
   {

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -30,6 +30,10 @@ export const MEMBERS: readonly Member[] = [
     memberOf: ['kotlin-sdk'],
   },
   {
+    github: 'a-akimov',
+    memberOf: ['docs-maintaners'],
+  },
+  {
     github: 'aaronpk',
     memberOf: ['auth-wg'],
   },


### PR DESCRIPTION
## Summary
- Add Alex Akimov to `docs-maintaners` team (replaces one-off repo permissions)
- Remove overly broad push access from `inspector` and `servers` repos (interest groups, working-groups umbrella)

## Why
- Team membership is easier to manage than scattered individual permissions
- Interest groups and umbrella groups don't need push access to inspector/servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)