### PR TITLE
Add pja-ant to transports WG

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -399,11 +399,7 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'pja-ant',
     discord: '328628782497923072',
-    memberOf: [
-      ROLE_IDS.CORE_MAINTAINERS,
-      ROLE_IDS.MAINTAINERS,
-      ROLE_IDS.TRANSPORT_WG
-    ],
+    memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.MAINTAINERS, ROLE_IDS.TRANSPORT_WG],
   },
   {
     github: 'pronskiy',


### PR DESCRIPTION
Adds pja-ant to the transports working group with Discord ID for role sync.