### PR TITLE
Add MCP_APPS_SDK role for ochafik (ext-apps access)

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -327,6 +327,7 @@ export const MEMBERS: readonly Member[] = [
     github: 'ochafik',
     discord: '1004897332069925024',
     memberOf: [
+      ROLE_IDS.MCP_APPS_SDK,
       ROLE_IDS.PYTHON_SDK,
       ROLE_IDS.PYTHON_SDK_AUTH,
       ROLE_IDS.TYPESCRIPT_SDK,


### PR DESCRIPTION
Adds the `MCP_APPS_SDK` role to grant admin access to the `ext-apps` repository.

**Changes:**
- Added `ROLE_IDS.MCP_APPS_SDK` to ochafik's `memberOf` list

**Access granted:**
- Admin access to `ext-apps` repository (via `mcp-apps-sdk` team)

Discord ID was already set correctly (`1004897332069925024`).