### PR TITLE
Add MCP_APPS_SDK role for antonpk1 (ext-apps access)

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -31,6 +31,11 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.GO_SDK],
   },
   {
+    github: 'antonpk1',
+    discord: '738474760480227358',
+    memberOf: [ROLE_IDS.MCP_APPS_SDK],
+  },
+  {
     github: 'asklar',
     discord: '633837375734153216',
     memberOf: [ROLE_IDS.MCPB_MAINTAINERS],


### PR DESCRIPTION
Adds the `MCP_APPS_SDK` role to grant admin access to the `ext-apps` repository.

**Changes:**
- Added new entry for `antonpk1` with `ROLE_IDS.MCP_APPS_SDK`

**Access granted:**
- Admin access to `ext-apps` repository (via `mcp-apps-sdk` team)

Discord ID: `738474760480227358`