### PR TITLE
Add MCP_APPS_SDK role for jonathanhefner (ext-apps access)

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -222,7 +222,12 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'jonathanhefner',
     discord: '1301960963087663186',
-    memberOf: [ROLE_IDS.DOCS_MAINTAINERS, ROLE_IDS.MODERATORS, ROLE_IDS.RUBY_SDK],
+    memberOf: [
+      ROLE_IDS.DOCS_MAINTAINERS,
+      ROLE_IDS.MODERATORS,
+      ROLE_IDS.RUBY_SDK,
+      ROLE_IDS.MCP_APPS_SDK,
+    ],
   },
   {
     github: 'jspahrsummers',


### PR DESCRIPTION
Adds the `MCP_APPS_SDK` role for `jonathanhefner` to grant admin access to the `ext-apps` repository.
