### PR TITLE
Add Discord ID for maxisbey

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -318,6 +318,7 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'maxisbey',
+    discord: '1404871241738748058',
     memberOf: [ROLE_IDS.PYTHON_SDK],
   },
   {


### PR DESCRIPTION
Add my Discord user ID to enable synced Discord roles for Python SDK maintainers.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>