### PR TITLE
Add CODEOWNERS: require core-maintainers for all changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files require approval from core-maintainers
+* @modelcontextprotocol/core-maintainers


### PR DESCRIPTION
Adds a CODEOWNERS file so that all PRs require review from @modelcontextprotocol/core-maintainers.\n\nThis pairs with the ruleset update enabling `require_code_owner_review`.