### PR TITLE
Rename auth-wg to auth-maintainers

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -18,7 +18,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     repository: 'docs',
     users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'docs-maintainers', permission: 'push' },
@@ -48,7 +48,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     repository: '.github',
     users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
-      { team: 'auth-wg', permission: 'triage' },
+      { team: 'auth-maintainers', permission: 'triage' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'triage' },
       { team: 'docs-maintainers', permission: 'triage' },
@@ -84,7 +84,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     ],
     teams: [
       { team: 'inspector-maintainers', permission: 'push' },
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'go-sdk', permission: 'push' },
@@ -110,7 +110,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     repository: 'modelcontextprotocol',
     users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'triage' },
       { team: 'docs-maintainers', permission: 'push' },
@@ -140,7 +140,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     repository: 'quickstart-resources',
     users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'docs-maintainers', permission: 'push' },
@@ -173,7 +173,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { username: 'slimslenderslacks', permission: 'push' },
     ],
     teams: [
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'admin' },
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'docs-maintainers', permission: 'push' },
@@ -306,7 +306,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: 'ext-auth',
-    teams: [{ team: 'auth-wg', permission: 'admin' }],
+    teams: [{ team: 'auth-maintainers', permission: 'admin' }],
   },
   {
     repository: 'ext-apps',

--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -46,7 +46,7 @@ export const ROLE_IDS = {
   // Working Groups
   // ===================
   WORKING_GROUPS: 'working-groups',
-  AUTH_WG: 'auth-wg',
+  AUTH_MAINTAINERS: 'auth-maintainers',
   SECURITY_WG: 'security-wg',
   SERVER_IDENTITY_WG: 'server-identity-wg',
   TRANSPORT_WG: 'transport-wg',

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -238,9 +238,9 @@ export const ROLES: readonly Role[] = [
     // No discord - organizational container
   },
   {
-    id: ROLE_IDS.AUTH_WG,
-    description: 'Authentication Working Group',
-    github: { team: 'auth-wg', parent: ROLE_IDS.WORKING_GROUPS },
+    id: ROLE_IDS.AUTH_MAINTAINERS,
+    description: 'Auth Maintainers',
+    github: { team: 'auth-maintainers', parent: ROLE_IDS.WORKING_GROUPS },
     // See AUTH_IG for Discord role
   },
   {
@@ -287,7 +287,7 @@ export const ROLES: readonly Role[] = [
     id: ROLE_IDS.AUTH_IG,
     description: 'Auth Interest Group',
     discord: { role: 'auth interest group (synced)' },
-    // Discord only - separate from AUTH_WG which is GitHub
+    // Discord only - separate from AUTH_MAINTAINERS which is GitHub
   },
   {
     id: ROLE_IDS.CLIENT_IMPLEMENTOR_IG,

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -15,7 +15,7 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'aaronpk',
     discord: '324624369428987905',
-    memberOf: [ROLE_IDS.AUTH_WG, ROLE_IDS.MAINTAINERS],
+    memberOf: [ROLE_IDS.AUTH_MAINTAINERS, ROLE_IDS.MAINTAINERS],
   },
   {
     github: 'alexhancock',
@@ -109,7 +109,7 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'D-McAdams',
     discord: '1364696680980545697',
-    memberOf: [ROLE_IDS.AUTH_WG],
+    memberOf: [ROLE_IDS.AUTH_MAINTAINERS],
   },
   {
     github: 'devcrocod',
@@ -124,7 +124,7 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'dsp',
     memberOf: [
-      ROLE_IDS.AUTH_WG,
+      ROLE_IDS.AUTH_MAINTAINERS,
       ROLE_IDS.LEAD_MAINTAINERS,
       ROLE_IDS.CORE_MAINTAINERS,
       ROLE_IDS.DOCS_MAINTAINERS,
@@ -143,7 +143,7 @@ export const MEMBERS: readonly Member[] = [
     email: 'david@modelcontextprotocol.io',
     discord: '166107790262272000',
     memberOf: [
-      ROLE_IDS.AUTH_WG,
+      ROLE_IDS.AUTH_MAINTAINERS,
       ROLE_IDS.LEAD_MAINTAINERS,
       ROLE_IDS.CORE_MAINTAINERS,
       ROLE_IDS.DOCS_MAINTAINERS,
@@ -286,7 +286,7 @@ export const MEMBERS: readonly Member[] = [
     github: 'localden',
     discord: '1351224014143754260',
     memberOf: [
-      ROLE_IDS.AUTH_WG,
+      ROLE_IDS.AUTH_MAINTAINERS,
       ROLE_IDS.CORE_MAINTAINERS,
       ROLE_IDS.CSHARP_SDK,
       ROLE_IDS.DOCS_MAINTAINERS,
@@ -402,7 +402,7 @@ export const MEMBERS: readonly Member[] = [
       ROLE_IDS.PYTHON_SDK_AUTH,
       ROLE_IDS.TYPESCRIPT_SDK,
       ROLE_IDS.TYPESCRIPT_SDK_AUTH,
-      ROLE_IDS.AUTH_WG,
+      ROLE_IDS.AUTH_MAINTAINERS,
     ],
   },
   {


### PR DESCRIPTION
## Summary

Renames the `auth-wg` GitHub team to `auth-maintainers` across the access config.

## Rationale

The `auth-wg` team has maintainer-level permissions -- it holds **admin** access on the `ext-auth` repo and **push** access on 6 other repos (docs, inspector, modelcontextprotocol, quickstart-resources, servers, and .github). The "working group" name no longer reflects this level of access; `auth-maintainers` better describes the team's actual role and responsibilities.

## Changes

- `src/config/roleIds.ts`: Renamed `AUTH_WG` constant to `AUTH_MAINTAINERS` with value `'auth-maintainers'`
- `src/config/roles.ts`: Updated the role definition (id, description, GitHub team name) and the AUTH_IG comment referencing it
- `src/config/users.ts`: Replaced all 6 occurrences of `ROLE_IDS.AUTH_WG` with `ROLE_IDS.AUTH_MAINTAINERS`
- `src/config/repoAccess.ts`: Replaced all 7 occurrences of `team: 'auth-wg'` with `team: 'auth-maintainers'`

## Deployment Note

Since the underlying GitHub team resource name changes, Pulumi would destroy and recreate the team if applied directly. I will manually rename the team on GitHub first (to `auth-maintainers`) before running the apply, so Pulumi adopts the existing team rather than recreating it.