### PR TITLE
Add `MAINTAINERS` and `COMMUNITY_MANAGERS` roles for jonathanhefner

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -251,7 +251,9 @@ export const MEMBERS: readonly Member[] = [
     github: 'jonathanhefner',
     discord: '1301960963087663186',
     memberOf: [
+      ROLE_IDS.COMMUNITY_MANAGERS,
       ROLE_IDS.DOCS_MAINTAINERS,
+      ROLE_IDS.MAINTAINERS,
       ROLE_IDS.MODERATORS,
       ROLE_IDS.RUBY_SDK,
       ROLE_IDS.MCP_APPS_SDK,


### PR DESCRIPTION
Adds `ROLE_IDS.MAINTAINERS` and `ROLE_IDS.COMMUNITY_MANAGERS` to `jonathanhefner` to match other community maintainers.
