### PR TITLE
Fix: Import auth-maintainers team into Pulumi state with correct ID

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,4 +71,8 @@ jobs:
           pulumi login gs://mcp-access-prod-pulumi-state
           pulumi config set discord:guildId "$DISCORD_GUILD_ID" --stack prod
           pulumi config set discord:botToken "$DISCORD_BOT_TOKEN" --secret --stack prod
+          # One-time import: auth-maintainers team exists on GitHub (ID 16083315)
+          # but was lost from Pulumi state during the auth-wg -> auth-maintainers rename.
+          # Remove this import line after the next successful deploy.
+          pulumi import github:index/team:Team auth-maintainers 16083315 --stack prod --yes || true
           make up


### PR DESCRIPTION
## Problem

The `auth-wg` -> `auth-maintainers` rename (PR #50) caused the team to be lost from Pulumi state. A previous import attempt (commit 8f29a9f) used the wrong team ID (`14435880`). The actual GitHub team ID is `16083315`.

Every deploy since has been failing with:
```
422 Validation Failed: Name must be unique for this org
```

The team itself is fine on GitHub with correct members and permissions (including admin on ext-auth), but no new access changes can be deployed until this is fixed.

## Fix

Adds a one-time `pulumi import` step with the correct team ID (`16083315`) to reconcile Pulumi state with the existing GitHub team.

## Follow-up

After this deploys successfully, a follow-up commit should remove the one-time import line from deploy.yml.