### PR TITLE
Add pederhp as community moderator and community manager

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -465,7 +465,13 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'pederhp',
     discord: '166255967665651713',
-    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.FINANCIAL_SERVICES_IG, ROLE_IDS.SKILLS_OVER_MCP_IG],
+    memberOf: [
+      ROLE_IDS.COMMUNITY_MANAGERS,
+      ROLE_IDS.MAINTAINERS,
+      ROLE_IDS.FINANCIAL_SERVICES_IG,
+      ROLE_IDS.MODERATORS,
+      ROLE_IDS.SKILLS_OVER_MCP_IG,
+    ],
   },
   {
     github: 'petery-ant',


### PR DESCRIPTION
## Summary

- Adds `ROLE_IDS.COMMUNITY_MANAGERS` and `ROLE_IDS.MODERATORS` to @PederHP's membership roles

This grants Peder:
- GitHub `moderators` team membership
- GitHub `community-managers` team membership
- Discord `community moderators (synced)` role
- Discord `community managers (synced)` role