### PR TITLE
Grant triggers-events-wg access to experimental-ext-triggers-events

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -330,6 +330,14 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     ],
   },
   {
+    repository: 'experimental-ext-triggers-events',
+    teams: [
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'moderators', permission: 'maintain' },
+      { team: 'triggers-events-wg', permission: 'admin' },
+    ],
+  },
+  {
     repository: 'maintainer-docs',
     teams: [
       { team: 'lead-maintainers', permission: 'maintain' },


### PR DESCRIPTION
Grants the `triggers-events-wg` team admin access to the newly created [experimental-ext-triggers-events](https://github.com/modelcontextprotocol/experimental-ext-triggers-events) repo so CODEOWNERS works.

Mirrors the `experimental-ext-skills` entry.

Validated with `scripts/validate-config.ts`.