### PR TITLE
Add the interceptors WG and set up the permissions appropriately

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -338,6 +338,14 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     ],
   },
   {
+    repository: 'experimental-ext-interceptors',
+    teams: [
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'moderators', permission: 'triage' },
+      { team: 'interceptors-wg', permission: 'admin' },
+    ],
+  },
+  {
     repository: 'maintainer-docs',
     teams: [
       { team: 'lead-maintainers', permission: 'maintain' },

--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -55,6 +55,7 @@ export const ROLE_IDS = {
   TRIGGERS_EVENTS_WG: 'triggers-events-wg',
   MCP_APPS_WG: 'mcp-apps-wg',
   SERVER_CARD_WG: 'server-card-wg',
+  INTERCEPTORS_WG: 'interceptors-wg',
 
   // ===================
   // Interest Groups

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -297,6 +297,12 @@ export const ROLES: readonly Role[] = [
     github: { team: 'server-card-wg', parent: ROLE_IDS.WORKING_GROUPS },
     discord: { role: 'server card working group (synced)' },
   },
+  {
+    id: ROLE_IDS.INTERCEPTORS_WG,
+    description: 'Interceptors Working Group',
+    github: { team: 'interceptors-wg', parent: ROLE_IDS.WORKING_GROUPS },
+    discord: { role: 'interceptors working group (synced)' },
+  },
 
   // ===================
   // Interest Groups

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -155,6 +155,10 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.RUST_SDK],
   },
   {
+    github: 'degiorgio',
+    memberOf: [ROLE_IDS.INTERCEPTORS_WG],
+  },
+  {
     github: 'dend',
     skipGoogleUserProvisioning: true,
     memberOf: [
@@ -568,6 +572,7 @@ export const MEMBERS: readonly Member[] = [
       ROLE_IDS.FINANCIAL_SERVICES_IG,
       ROLE_IDS.MODERATORS,
       ROLE_IDS.SKILLS_OVER_MCP_IG,
+      ROLE_IDS.INTERCEPTORS_WG,
     ],
   },
   {
@@ -625,7 +630,7 @@ export const MEMBERS: readonly Member[] = [
     lastName: 'Kothari',
     googleEmailPrefix: 'sambhav',
     discord: '840109459212206090',
-    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.FINANCIAL_SERVICES_IG],
+    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.FINANCIAL_SERVICES_IG, ROLE_IDS.INTERCEPTORS_WG],
   },
   {
     github: 'SamMorrowDrums',


### PR DESCRIPTION
Correctly sets up the github permissions for the interceptors WG as we are having a wider WG kickoff this thursday and we expect more participants.

Sets the current WG maintainers to be - 
- @sambhav 
- @PederHP 
- @degiorgio 

who are already contributing to the repo.

More to be added a folks start contributing.