### PR TITLE
feat: add Google Workspace account for SamMorrowDrums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 bin/
 *.log
+.devenv/
+.devenv.flake.nix
+devenv.lock
 
 # Pulumi
 .pulumi/

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,9 @@ preview: login ## Preview infrastructure changes
 refresh: login ## Refresh state to match reality
 	PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi refresh --yes --stack prod
 
-up: login ## Deploy infrastructure
+up: login ## Deploy infrastructure (with refresh to detect drift, e.g. expired org invites)
+	# Dynamic providers serialize their implementation into state. Run a plain
+	# `up` first so any provider-code changes are captured, then refresh with the
+	# freshly serialized `read()`. Otherwise refresh runs stale code and fails.
 	PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi up --yes --stack prod
+	PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi up --refresh --yes --stack prod

--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -6,4 +6,5 @@ packages:
     source: terraform-provider
     version: 0.14.0
     parameters:
-      - hashicorp/googleworkspace
+      - SamuZad/googleworkspace
+      - 0.11.1

--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ Infrastructure as Code for managing access to MCP community resources using Pulu
 - **GitHub Teams**: Automatically syncs team memberships in the MCP GitHub organization
 - **Google Workspace Groups**: Automatically syncs group memberships for @modelcontextprotocol.io email accounts
   - **Email Groups**: Groups with `isEmailGroup: true` accept emails from anyone (including external users) and notify all members. External posts are moderated for security.
+- **Google Workspace User Accounts**: Provisions @modelcontextprotocol.io accounts for members of roles with `provisionUser: true`
+
+### Opting in to a Google Workspace account (maintainers)
+
+If you're a maintainer and want an `@modelcontextprotocol.io` account, open a PR adding the following fields to your entry in [`src/config/users.ts`](src/config/users.ts):
+
+```ts
+{
+  github: 'your-github-username',
+  // ...
+  firstName: 'Your',
+  lastName: 'Name',
+  googleEmailPrefix: 'yourname', // -> yourname@modelcontextprotocol.io
+  memberOf: [ROLE_IDS.MAINTAINERS /* , ... */],
+},
+```
+
+Once merged, Pulumi provisions the account. An admin will share your initial password (retrievable via `pulumi stack output --show-secrets newGWSUserPasswords`).
 
 ## Deployment
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  packages = [
+    pkgs.google-cloud-sdk
+    pkgs.nodejs_22
+    pkgs.pulumi-bin
+    pkgs.pulumiPackages.pulumi-nodejs
+  ];
+}

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@pulumi/github": "^6.7.3",
+    "@pulumi/github": "^6.11.0",
     "@pulumi/googleworkspace": "file:sdks/googleworkspace",
-    "@pulumi/pulumi": "^3.197.0"
+    "@pulumi/pulumi": "^3.218.0",
+    "@pulumi/random": "^4.14.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.6",
     "prettier": "^3.7.2",
+    "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
   }
 }

--- a/scripts/test-config.ts
+++ b/scripts/test-config.ts
@@ -82,6 +82,51 @@ test('TYPESCRIPT_SDK_AUTH role exists (GitHub-only)', () => {
   return role !== undefined && role.github !== undefined && role.discord === undefined;
 });
 
+// Test Google Workspace user provisioning
+test('Roles with provisionUser exist', () => {
+  const provisionRoles = ROLES.filter((r) => r.google?.provisionUser);
+  return provisionRoles.length > 0;
+});
+
+test('Members with googleEmailPrefix have firstName and lastName', () =>
+  MEMBERS.every((m) => {
+    if (!m.googleEmailPrefix) return true;
+    return !!m.firstName && !!m.lastName;
+  }));
+
+test('googleEmailPrefix values are unique', () => {
+  const prefixes = MEMBERS.filter((m) => m.googleEmailPrefix).map((m) => m.googleEmailPrefix);
+  return prefixes.length === new Set(prefixes).size;
+});
+
+test('skipGoogleUserProvisioning is only used in provisionUser roles and without fields', () => {
+  const provisionRoleIds = new Set(ROLES.filter((r) => r.google?.provisionUser).map((r) => r.id));
+  return MEMBERS.every((member) => {
+    const inProvisionRole = member.memberOf.some((id) => provisionRoleIds.has(id));
+    if (!inProvisionRole) return !member.skipGoogleUserProvisioning;
+
+    const hasProvisioningFields = !!(
+      member.firstName &&
+      member.lastName &&
+      member.googleEmailPrefix
+    );
+    return !(hasProvisioningFields && member.skipGoogleUserProvisioning);
+  });
+});
+
+test('Some members in provisionUser roles have Google user fields', () => {
+  const membersInProvisionRoles = MEMBERS.filter((m) =>
+    m.memberOf.some((id) => {
+      const role = roleLookup.get(id);
+      return role?.google?.provisionUser === true;
+    })
+  );
+  const provisioned = membersInProvisionRoles.filter(
+    (m) => m.firstName && m.lastName && m.googleEmailPrefix
+  );
+  return membersInProvisionRoles.length > 0 && provisioned.length > 0;
+});
+
 // Summary
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/scripts/validate-config.ts
+++ b/scripts/validate-config.ts
@@ -98,6 +98,65 @@ console.log('Validating member ordering in users.ts...');
   }
 }
 
+// Validate Google Workspace user provisioning fields
+console.log('Validating Google Workspace user provisioning fields...');
+{
+  const googleEmailPrefixes = new Map<string, string>();
+
+  for (const member of MEMBERS) {
+    const memberId = member.github || member.email || 'unknown';
+
+    // Members with googleEmailPrefix must also have firstName and lastName
+    if (member.googleEmailPrefix) {
+      if (!member.firstName) {
+        console.error(`ERROR: Member "${memberId}" has googleEmailPrefix but is missing firstName`);
+        hasErrors = true;
+      }
+      if (!member.lastName) {
+        console.error(`ERROR: Member "${memberId}" has googleEmailPrefix but is missing lastName`);
+        hasErrors = true;
+      }
+
+      // Check uniqueness of googleEmailPrefix
+      const existing = googleEmailPrefixes.get(member.googleEmailPrefix);
+      if (existing) {
+        console.error(
+          `ERROR: googleEmailPrefix "${member.googleEmailPrefix}" is used by both "${existing}" and "${memberId}"`
+        );
+        hasErrors = true;
+      } else {
+        googleEmailPrefixes.set(member.googleEmailPrefix, memberId);
+      }
+    }
+
+    // Members in provisionUser roles without all three fields won't get a GWS account
+    const inProvisionUserRole = member.memberOf.some((roleId: RoleId) => {
+      const role = roleLookup.get(roleId);
+      return role?.google?.provisionUser === true;
+    });
+
+    const hasProvisioningFields = !!(
+      member.googleEmailPrefix &&
+      member.firstName &&
+      member.lastName
+    );
+
+    if (member.skipGoogleUserProvisioning && !inProvisionUserRole) {
+      console.error(
+        `ERROR: Member "${memberId}" has skipGoogleUserProvisioning=true but is not in a provisionUser role`
+      );
+      hasErrors = true;
+    }
+
+    if (inProvisionUserRole && hasProvisioningFields && member.skipGoogleUserProvisioning) {
+      console.error(
+        `ERROR: Member "${memberId}" has provisioning fields and skipGoogleUserProvisioning=true; pick one`
+      );
+      hasErrors = true;
+    }
+  }
+}
+
 // Validate parent role references in roles.ts
 console.log('Validating parent role references in roles.ts...');
 for (const role of ROLES) {

--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -16,9 +16,8 @@ export interface RepositoryAccess {
 export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   {
     repository: 'docs',
-    users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'docs-maintainers', permission: 'push' },
@@ -27,7 +26,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'interest-groups', permission: 'push' },
       { team: 'java-sdk', permission: 'push' },
       { team: 'kotlin-sdk', permission: 'push' },
-      { team: 'moderators', permission: 'push' },
+      { team: 'moderators', permission: 'maintain' },
       { team: 'php-sdk', permission: 'push' },
       { team: 'python-sdk', permission: 'push' },
       { team: 'python-sdk-auth', permission: 'push' },
@@ -46,9 +45,8 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: '.github',
-    users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
-      { team: 'auth-wg', permission: 'triage' },
+      { team: 'auth-maintainers', permission: 'triage' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'triage' },
       { team: 'docs-maintainers', permission: 'triage' },
@@ -57,7 +55,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'interest-groups', permission: 'triage' },
       { team: 'java-sdk', permission: 'triage' },
       { team: 'kotlin-sdk', permission: 'triage' },
-      { team: 'moderators', permission: 'push' },
+      { team: 'moderators', permission: 'maintain' },
       { team: 'php-sdk', permission: 'triage' },
       { team: 'python-sdk', permission: 'triage' },
       { team: 'python-sdk-auth', permission: 'triage' },
@@ -76,21 +74,15 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: 'inspector',
-    users: [
-      { username: 'richardkmichael', permission: 'triage' },
-      { username: 'jspahrsummers', permission: 'admin' },
-      { username: 'an-dustin', permission: 'admin' },
-      { username: 'ashwin-ant', permission: 'admin' },
-    ],
     teams: [
       { team: 'inspector-maintainers', permission: 'push' },
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'go-sdk', permission: 'push' },
       { team: 'java-sdk', permission: 'push' },
       { team: 'kotlin-sdk', permission: 'push' },
-      { team: 'moderators', permission: 'push' },
+      { team: 'moderators', permission: 'maintain' },
       { team: 'php-sdk', permission: 'push' },
       { team: 'python-sdk', permission: 'push' },
       { team: 'python-sdk-auth', permission: 'push' },
@@ -108,9 +100,8 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: 'modelcontextprotocol',
-    users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'triage' },
       { team: 'docs-maintainers', permission: 'push' },
@@ -119,7 +110,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'interest-groups', permission: 'triage' },
       { team: 'java-sdk', permission: 'triage' },
       { team: 'kotlin-sdk', permission: 'triage' },
-      { team: 'moderators', permission: 'triage' },
+      { team: 'moderators', permission: 'maintain' },
       { team: 'php-sdk', permission: 'triage' },
       { team: 'python-sdk', permission: 'triage' },
       { team: 'python-sdk-auth', permission: 'triage' },
@@ -138,9 +129,8 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: 'quickstart-resources',
-    users: [{ username: 'jspahrsummers', permission: 'admin' }],
     teams: [
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'docs-maintainers', permission: 'push' },
@@ -149,7 +139,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'interest-groups', permission: 'push' },
       { team: 'java-sdk', permission: 'push' },
       { team: 'kotlin-sdk', permission: 'push' },
-      { team: 'moderators', permission: 'push' },
+      { team: 'moderators', permission: 'maintain' },
       { team: 'php-sdk', permission: 'push' },
       { team: 'python-sdk', permission: 'push' },
       { team: 'python-sdk-auth', permission: 'push' },
@@ -168,19 +158,16 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: 'servers',
-    users: [
-      { username: 'jspahrsummers', permission: 'admin' },
-      { username: 'slimslenderslacks', permission: 'push' },
-    ],
     teams: [
-      { team: 'auth-wg', permission: 'push' },
+      { team: 'reference-servers-maintainers', permission: 'admin' },
+      { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'admin' },
       { team: 'csharp-sdk', permission: 'push' },
       { team: 'docs-maintainers', permission: 'push' },
       { team: 'go-sdk', permission: 'push' },
       { team: 'java-sdk', permission: 'push' },
       { team: 'kotlin-sdk', permission: 'push' },
-      { team: 'moderators', permission: 'push' },
+      { team: 'moderators', permission: 'maintain' },
       { team: 'php-sdk', permission: 'push' },
       { team: 'python-sdk', permission: 'push' },
       { team: 'python-sdk-auth', permission: 'push' },
@@ -198,25 +185,15 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: 'csharp-sdk',
-    teams: [{ team: 'csharp-sdk', permission: 'admin' }],
-    users: [
-      { username: 'jeffhandley', permission: 'admin' },
-      { username: 'MackinnonBuck', permission: 'admin' },
-      { username: 'jozkee', permission: 'admin' },
-      { username: 'localden', permission: 'admin' },
-      { username: 'PederHP', permission: 'triage' },
-      { username: 'tarekgh', permission: 'push' },
+    teams: [
+      { team: 'csharp-sdk-admin', permission: 'admin' },
+      { team: 'csharp-sdk', permission: 'maintain' },
     ],
+    users: [{ username: 'PederHP', permission: 'triage' }],
   },
   {
     repository: 'go-sdk',
     teams: [{ team: 'go-sdk', permission: 'admin' }],
-    users: [
-      { username: 'neild', permission: 'push' },
-      { username: 'rsc', permission: 'push' },
-      { username: 'rolandshoemaker', permission: 'push' },
-      { username: 'h9jiang', permission: 'maintain' },
-    ],
   },
   {
     repository: 'java-sdk',
@@ -236,7 +213,6 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'python-sdk', permission: 'admin' },
       { team: 'python-sdk-auth', permission: 'admin' },
     ],
-    users: [{ username: 'jspahrsummers', permission: 'admin' }],
   },
   {
     repository: 'ruby-sdk',
@@ -245,30 +221,18 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   {
     repository: 'rust-sdk',
     teams: [{ team: 'rust-sdk', permission: 'admin' }],
-    users: [
-      { username: 'jamadeo', permission: 'admin' },
-      { username: 'jokemanfire', permission: 'push' },
-      { username: '4t145', permission: 'push' },
-      { username: 'bolinfest', permission: 'push' },
-      { username: 'alexhancock', permission: 'push' },
-    ],
   },
   {
     repository: 'swift-sdk',
-    teams: [{ team: 'swift-sdk', permission: 'push' }],
-    users: [
-      { username: 'mattt', permission: 'admin' },
-      { username: 'movetz', permission: 'admin' },
-      { username: 'stallent', permission: 'admin' },
-    ],
+    teams: [{ team: 'swift-sdk', permission: 'admin' }],
   },
   {
     repository: 'typescript-sdk',
     teams: [
       { team: 'typescript-sdk', permission: 'admin' },
       { team: 'typescript-sdk-auth', permission: 'admin' },
+      { team: 'typescript-sdk-collaborators', permission: 'push' },
     ],
-    users: [{ username: 'jspahrsummers', permission: 'admin' }],
   },
   {
     repository: 'create-python-server',
@@ -287,7 +251,6 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   {
     repository: 'registry',
     teams: [{ team: 'registry-wg', permission: 'admin' }],
-    users: [{ username: 'rdimitrov', permission: 'admin' }],
   },
   {
     repository: 'static',
@@ -299,29 +262,25 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     users: [
       { username: 'aniabot', permission: 'pull' },
       { username: 'imfing', permission: 'triage' },
-      { username: 'sambhav', permission: 'admin' },
       { username: 'KengoA', permission: 'triage' },
       { username: 'nitsanh', permission: 'pull' },
     ],
   },
   {
     repository: 'ext-auth',
-    teams: [{ team: 'auth-wg', permission: 'admin' }],
+    teams: [{ team: 'auth-maintainers', permission: 'admin' }],
   },
   {
     repository: 'ext-apps',
     teams: [
       { team: 'core-maintainers', permission: 'push' },
-      { team: 'moderators', permission: 'triage' },
+      { team: 'moderators', permission: 'maintain' },
       { team: 'mcp-apps-wg', permission: 'push' },
       { team: 'mcp-apps-sdk', permission: 'admin' },
     ],
     users: [
-      { username: 'liady', permission: 'admin' },
-      { username: 'idosal', permission: 'admin' },
       { username: 'ststrong', permission: 'admin' },
       { username: 'martinalong', permission: 'push' },
-      { username: 'antonpk1', permission: 'admin' },
       { username: 'conorkel', permission: 'admin' },
       { username: 'alexi-openai', permission: 'admin' },
     ],
@@ -330,7 +289,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     repository: 'use-mcp',
     teams: [
       { team: 'core-maintainers', permission: 'push' },
-      { team: 'moderators', permission: 'triage' },
+      { team: 'moderators', permission: 'maintain' },
     ],
     users: [{ username: 'geelen', permission: 'admin' }],
   },
@@ -338,12 +297,60 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     repository: 'example-remote-client',
     teams: [
       { team: 'core-maintainers', permission: 'push' },
-      { team: 'moderators', permission: 'triage' },
+      { team: 'moderators', permission: 'maintain' },
     ],
     users: [
       { username: 'geelen', permission: 'push' },
       { username: 'markyfyi', permission: 'push' },
       { username: 'jerryhong1', permission: 'push' },
+    ],
+  },
+  {
+    repository: 'experimental-ext-grouping',
+    teams: [
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'moderators', permission: 'maintain' },
+      { team: 'primitive-grouping-ig', permission: 'admin' },
+    ],
+  },
+  {
+    repository: 'experimental-ext-skills',
+    teams: [
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'moderators', permission: 'maintain' },
+      { team: 'skills-over-mcp-ig', permission: 'admin' },
+    ],
+  },
+  {
+    repository: 'experimental-ext-tool-annotations',
+    teams: [
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'moderators', permission: 'triage' },
+      { team: 'tool-annotations-ig', permission: 'admin' },
+    ],
+  },
+  {
+    repository: 'experimental-ext-triggers-events',
+    teams: [
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'moderators', permission: 'maintain' },
+      { team: 'triggers-events-wg', permission: 'admin' },
+    ],
+  },
+  {
+    repository: 'maintainer-docs',
+    teams: [
+      { team: 'lead-maintainers', permission: 'maintain' },
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'steering-committee', permission: 'maintain' },
+    ],
+    users: [{ username: 'sambhav', permission: 'admin' }],
+  },
+  {
+    repository: 'community-moderators',
+    teams: [
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'moderators', permission: 'maintain' },
     ],
   },
 ];

--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -29,6 +29,7 @@ export const ROLE_IDS = {
   // ===================
   SDK_MAINTAINERS: 'sdk-maintainers',
   CSHARP_SDK: 'csharp-sdk',
+  CSHARP_SDK_ADMIN: 'csharp-sdk-admin',
   GO_SDK: 'go-sdk',
   JAVA_SDK: 'java-sdk',
   KOTLIN_SDK: 'kotlin-sdk',
@@ -41,16 +42,19 @@ export const ROLE_IDS = {
   SWIFT_SDK: 'swift-sdk',
   TYPESCRIPT_SDK: 'typescript-sdk',
   TYPESCRIPT_SDK_AUTH: 'typescript-sdk-auth', // GitHub only (CODEOWNERS)
+  TYPESCRIPT_SDK_COLLABORATORS: 'typescript-sdk-collaborators', // GitHub only
 
   // ===================
   // Working Groups
   // ===================
   WORKING_GROUPS: 'working-groups',
-  AUTH_WG: 'auth-wg',
+  AUTH_MAINTAINERS: 'auth-maintainers',
   SECURITY_WG: 'security-wg',
   SERVER_IDENTITY_WG: 'server-identity-wg',
   TRANSPORT_WG: 'transport-wg',
+  TRIGGERS_EVENTS_WG: 'triggers-events-wg',
   MCP_APPS_WG: 'mcp-apps-wg',
+  SERVER_CARD_WG: 'server-card-wg',
 
   // ===================
   // Interest Groups
@@ -61,6 +65,9 @@ export const ROLE_IDS = {
   CLIENT_IMPLEMENTOR_IG: 'client-implementor-ig',
   FINANCIAL_SERVICES_IG: 'financial-services-ig',
   GATEWAYS_IG: 'gateways-ig',
+  PRIMITIVE_GROUPING_IG: 'primitive-grouping-ig',
+  SKILLS_OVER_MCP_IG: 'skills-over-mcp-ig',
+  TOOL_ANNOTATIONS_IG: 'tool-annotations-ig',
 
   // ===================
   // WG/IG Facilitators (Discord only)

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -26,6 +26,8 @@ export interface GoogleConfig {
   group: string;
   /** If true, accepts emails from anyone including external users */
   isEmailGroup?: boolean;
+  /** If true, members of this role get a Google Workspace user account */
+  provisionUser?: boolean;
 }
 
 /**
@@ -77,19 +79,21 @@ export const ROLES: readonly Role[] = [
     description: 'Lead core maintainers',
     github: { team: 'lead-maintainers', parent: ROLE_IDS.STEERING_COMMITTEE },
     discord: { role: 'lead maintainers (synced)' },
-    // Discord only for now - could add GitHub if needed
+    google: { group: 'lead-maintainers', provisionUser: true },
   },
   {
     id: ROLE_IDS.CORE_MAINTAINERS,
     description: 'Core maintainers',
     github: { team: 'core-maintainers', parent: ROLE_IDS.STEERING_COMMITTEE },
     discord: { role: 'core maintainers (synced)' },
+    google: { group: 'core-maintainers', provisionUser: true },
   },
   {
     id: ROLE_IDS.MODERATORS,
     description: 'Community moderators',
     github: { team: 'moderators', parent: ROLE_IDS.STEERING_COMMITTEE },
     discord: { role: 'community moderators (synced)' },
+    google: { group: 'moderators', provisionUser: true },
   },
 
   // ===================
@@ -99,7 +103,9 @@ export const ROLES: readonly Role[] = [
     id: ROLE_IDS.MAINTAINERS,
     description: 'General maintainers',
     discord: { role: 'maintainers (synced)' },
-    // Discord only - general maintainer role
+    // GWS user accounts are opt-in: maintainers add firstName/lastName/googleEmailPrefix
+    // to their entry in users.ts via PR to get an @modelcontextprotocol.io account
+    google: { group: 'maintainers', provisionUser: true },
   },
   {
     id: ROLE_IDS.DOCS_MAINTAINERS,
@@ -122,15 +128,15 @@ export const ROLES: readonly Role[] = [
   {
     id: ROLE_IDS.REFERENCE_SERVERS_MAINTAINERS,
     description: 'Reference servers maintainers',
+    github: { team: 'reference-servers-maintainers' },
     discord: { role: 'reference servers maintainers (synced)' },
-    // Discord only for now
   },
   {
     id: ROLE_IDS.REGISTRY_MAINTAINERS,
     description: 'Official registry builders and maintainers',
     github: { team: 'registry-wg', parent: ROLE_IDS.WORKING_GROUPS },
     discord: { role: 'registry maintainers (synced)' },
-    google: { group: 'registry-wg' },
+    google: { group: 'registry-wg', provisionUser: true },
   },
   {
     id: ROLE_IDS.USE_MCP_MAINTAINERS,
@@ -154,6 +160,12 @@ export const ROLES: readonly Role[] = [
     description: 'Official C# SDK maintainers',
     github: { team: 'csharp-sdk', parent: ROLE_IDS.SDK_MAINTAINERS },
     discord: { role: 'c# sdk maintainers (synced)' },
+  },
+  {
+    id: ROLE_IDS.CSHARP_SDK_ADMIN,
+    description: 'C# SDK repository admins',
+    github: { team: 'csharp-sdk-admin', parent: ROLE_IDS.CSHARP_SDK },
+    // GitHub only - for repo admin access
   },
   {
     id: ROLE_IDS.GO_SDK,
@@ -227,6 +239,12 @@ export const ROLES: readonly Role[] = [
     github: { team: 'typescript-sdk-auth', parent: ROLE_IDS.TYPESCRIPT_SDK },
     // GitHub only - for CODEOWNERS
   },
+  {
+    id: ROLE_IDS.TYPESCRIPT_SDK_COLLABORATORS,
+    description: 'TypeScript SDK collaborators',
+    github: { team: 'typescript-sdk-collaborators', parent: ROLE_IDS.TYPESCRIPT_SDK },
+    // GitHub only
+  },
 
   // ===================
   // Working Groups
@@ -238,9 +256,9 @@ export const ROLES: readonly Role[] = [
     // No discord - organizational container
   },
   {
-    id: ROLE_IDS.AUTH_WG,
-    description: 'Authentication Working Group',
-    github: { team: 'auth-wg', parent: ROLE_IDS.WORKING_GROUPS },
+    id: ROLE_IDS.AUTH_MAINTAINERS,
+    description: 'Auth Maintainers',
+    github: { team: 'auth-maintainers', parent: ROLE_IDS.WORKING_GROUPS },
     // See AUTH_IG for Discord role
   },
   {
@@ -262,10 +280,22 @@ export const ROLES: readonly Role[] = [
     discord: { role: 'transports working group (synced)' },
   },
   {
+    id: ROLE_IDS.TRIGGERS_EVENTS_WG,
+    description: 'Triggers & Events Working Group',
+    github: { team: 'triggers-events-wg', parent: ROLE_IDS.WORKING_GROUPS },
+    discord: { role: 'triggers & events working group (synced)' },
+  },
+  {
     id: ROLE_IDS.MCP_APPS_WG,
     description: 'MCP Apps Working Group',
     github: { team: 'mcp-apps-wg', parent: ROLE_IDS.WORKING_GROUPS },
     discord: { role: 'mcp apps working group (synced)' },
+  },
+  {
+    id: ROLE_IDS.SERVER_CARD_WG,
+    description: 'Server Card Working Group',
+    github: { team: 'server-card-wg', parent: ROLE_IDS.WORKING_GROUPS },
+    discord: { role: 'server card working group (synced)' },
   },
 
   // ===================
@@ -287,7 +317,7 @@ export const ROLES: readonly Role[] = [
     id: ROLE_IDS.AUTH_IG,
     description: 'Auth Interest Group',
     discord: { role: 'auth interest group (synced)' },
-    // Discord only - separate from AUTH_WG which is GitHub
+    // Discord only - separate from AUTH_MAINTAINERS which is GitHub
   },
   {
     id: ROLE_IDS.CLIENT_IMPLEMENTOR_IG,
@@ -306,6 +336,24 @@ export const ROLES: readonly Role[] = [
     description: 'Gateways Interest Group',
     // No GitHub role yet
     discord: { role: 'gateways interest group (synced)' },
+  },
+  {
+    id: ROLE_IDS.PRIMITIVE_GROUPING_IG,
+    description: 'Primitive Grouping Interest Group',
+    github: { team: 'primitive-grouping-ig', parent: ROLE_IDS.INTEREST_GROUPS },
+    discord: { role: 'primitive grouping interest group (synced)' },
+  },
+  {
+    id: ROLE_IDS.SKILLS_OVER_MCP_IG,
+    description: 'Skills Over MCP Interest Group',
+    github: { team: 'skills-over-mcp-ig', parent: ROLE_IDS.INTEREST_GROUPS },
+    discord: { role: 'skills over mcp interest group (synced)' },
+  },
+  {
+    id: ROLE_IDS.TOOL_ANNOTATIONS_IG,
+    description: 'Tool Annotations Interest Group',
+    github: { team: 'tool-annotations-ig', parent: ROLE_IDS.INTEREST_GROUPS },
+    discord: { role: 'tool annotations interest group (synced)' },
   },
 
   // ===================

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -5,6 +5,9 @@ export const MEMBERS: readonly Member[] = [
   {
     github: '000-000-000-000-000',
     discord: '1360717264051241071',
+    firstName: 'Nick',
+    lastName: 'Aldridge',
+    googleEmailPrefix: 'nick',
     memberOf: [ROLE_IDS.CORE_MAINTAINERS],
   },
   {
@@ -15,7 +18,7 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'aaronpk',
     discord: '324624369428987905',
-    memberOf: [ROLE_IDS.AUTH_WG, ROLE_IDS.MAINTAINERS],
+    memberOf: [ROLE_IDS.AUTH_MAINTAINERS, ROLE_IDS.MAINTAINERS],
   },
   {
     github: 'alexhancock',
@@ -25,10 +28,6 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'an-dustin',
     memberOf: [ROLE_IDS.SECURITY_WG],
-  },
-  {
-    github: 'ansaba',
-    memberOf: [ROLE_IDS.GO_SDK],
   },
   {
     github: 'antonpk1',
@@ -54,7 +53,6 @@ export const MEMBERS: readonly Member[] = [
     github: 'bhosmer-ant',
     discord: '1272295077074567242',
     memberOf: [
-      ROLE_IDS.CORE_MAINTAINERS,
       ROLE_IDS.DOCS_MAINTAINERS,
       ROLE_IDS.MODERATORS,
       ROLE_IDS.PYTHON_SDK,
@@ -62,15 +60,29 @@ export const MEMBERS: readonly Member[] = [
     ],
   },
   {
+    github: 'BobDickinson',
+    email: 'bob.dickinson@gmail.com',
+    discord: '1175893001202045139',
+    skipGoogleUserProvisioning: true,
+    memberOf: [
+      ROLE_IDS.MAINTAINERS,
+      ROLE_IDS.INSPECTOR_MAINTAINERS,
+      ROLE_IDS.REGISTRY_MAINTAINERS,
+      ROLE_IDS.SKILLS_OVER_MCP_IG,
+    ],
+  },
+  {
+    github: 'bolinfest',
+    memberOf: [ROLE_IDS.RUST_SDK],
+  },
+  {
     github: 'caitiem20',
     email: 'caitie.mccaffrey@microsoft.com',
     discord: '1425586366288494722',
+    firstName: 'Caitie',
+    lastName: 'McCaffrey',
+    googleEmailPrefix: 'caitie',
     memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.TRANSPORT_WG],
-  },
-  {
-    github: 'carlpeaslee',
-    discord: '288330838951723009',
-    memberOf: [ROLE_IDS.SWIFT_SDK],
   },
   {
     github: 'chemicL',
@@ -84,16 +96,42 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.PHP_SDK],
   },
   {
+    github: 'chughtapan',
+    email: 'chugh.tapan@gmail.com',
+    discord: '941245973357793340',
+    memberOf: [
+      ROLE_IDS.MAINTAINERS,
+      ROLE_IDS.INTEREST_GROUPS,
+      ROLE_IDS.PRIMITIVE_GROUPING_IG,
+      ROLE_IDS.WG_IG_FACILITATORS,
+    ],
+  },
+  {
+    github: 'clareliguori',
+    email: 'liguori@amazon.com',
+    discord: '1109135863843143700',
+    firstName: 'Clare',
+    lastName: 'Liguori',
+    googleEmailPrefix: 'clare',
+    memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.TRIGGERS_EVENTS_WG],
+  },
+  {
     github: 'cliffhall',
     email: 'cliff@futurescale.com',
     discord: '501498061965754380',
+    firstName: 'Cliff',
+    lastName: 'Hall',
+    googleEmailPrefix: 'cliff',
+    existingGWSUser: true,
     memberOf: [
       ROLE_IDS.COMMUNITY_MANAGERS,
       ROLE_IDS.MAINTAINERS,
       ROLE_IDS.DOCS_MAINTAINERS,
       ROLE_IDS.INSPECTOR_MAINTAINERS,
+      ROLE_IDS.PRIMITIVE_GROUPING_IG,
       ROLE_IDS.REFERENCE_SERVERS_MAINTAINERS,
       ROLE_IDS.MODERATORS,
+      ROLE_IDS.SKILLS_OVER_MCP_IG,
       ROLE_IDS.WORKING_GROUPS,
     ],
   },
@@ -109,7 +147,32 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'D-McAdams',
     discord: '1364696680980545697',
-    memberOf: [ROLE_IDS.AUTH_WG],
+    memberOf: [ROLE_IDS.AUTH_MAINTAINERS],
+  },
+  {
+    github: 'daleseo',
+    discord: '267646459187298305',
+    memberOf: [ROLE_IDS.RUST_SDK],
+  },
+  {
+    github: 'dend',
+    skipGoogleUserProvisioning: true,
+    memberOf: [
+      ROLE_IDS.AUTH_MAINTAINERS,
+      ROLE_IDS.CORE_MAINTAINERS,
+      ROLE_IDS.LEAD_MAINTAINERS,
+      ROLE_IDS.DOCS_MAINTAINERS,
+      ROLE_IDS.CSHARP_SDK_ADMIN,
+      ROLE_IDS.ADMINISTRATORS,
+      ROLE_IDS.GO_SDK,
+      ROLE_IDS.FINANCIAL_SERVICES_IG,
+      ROLE_IDS.MODERATORS,
+      ROLE_IDS.PHP_SDK,
+      ROLE_IDS.PYTHON_SDK,
+      ROLE_IDS.SECURITY_WG,
+      ROLE_IDS.TRANSPORT_WG,
+      ROLE_IDS.TYPESCRIPT_SDK,
+    ],
   },
   {
     github: 'devcrocod',
@@ -119,12 +182,17 @@ export const MEMBERS: readonly Member[] = [
     github: 'domdomegg',
     email: 'adam@modelcontextprotocol.io',
     discord: '102128241715716096',
+    firstName: 'Adam',
+    lastName: 'Jones',
+    googleEmailPrefix: 'adam',
+    existingGWSUser: true,
     memberOf: [ROLE_IDS.MCPB_MAINTAINERS, ROLE_IDS.REGISTRY_MAINTAINERS],
   },
   {
     github: 'dsp',
+    skipGoogleUserProvisioning: true,
     memberOf: [
-      ROLE_IDS.AUTH_WG,
+      ROLE_IDS.AUTH_MAINTAINERS,
       ROLE_IDS.LEAD_MAINTAINERS,
       ROLE_IDS.CORE_MAINTAINERS,
       ROLE_IDS.DOCS_MAINTAINERS,
@@ -142,19 +210,17 @@ export const MEMBERS: readonly Member[] = [
     github: 'dsp-ant',
     email: 'david@modelcontextprotocol.io',
     discord: '166107790262272000',
+    firstName: 'David',
+    lastName: 'Soria Parra',
+    googleEmailPrefix: 'david',
+    existingGWSUser: true,
     memberOf: [
-      ROLE_IDS.AUTH_WG,
+      ROLE_IDS.AUTH_MAINTAINERS,
       ROLE_IDS.LEAD_MAINTAINERS,
       ROLE_IDS.CORE_MAINTAINERS,
       ROLE_IDS.DOCS_MAINTAINERS,
-      ROLE_IDS.GO_SDK,
-      ROLE_IDS.FINANCIAL_SERVICES_IG,
       ROLE_IDS.MODERATORS,
-      ROLE_IDS.PHP_SDK,
-      ROLE_IDS.PYTHON_SDK,
-      ROLE_IDS.SECURITY_WG,
-      ROLE_IDS.TRANSPORT_WG,
-      ROLE_IDS.TYPESCRIPT_SDK,
+      ROLE_IDS.SERVER_CARD_WG,
     ],
   },
   {
@@ -171,9 +237,26 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.WG_IG_FACILITATORS],
   },
   {
+    github: 'erain',
+    discord: '797226095874539539',
+    memberOf: [ROLE_IDS.SKILLS_OVER_MCP_IG],
+  },
+  {
+    github: 'ericstj',
+    memberOf: [ROLE_IDS.CSHARP_SDK],
+  },
+  {
     github: 'evalstate',
     discord: '779268016121577492',
-    memberOf: [ROLE_IDS.COMMUNITY_MANAGERS, ROLE_IDS.DOCS_MAINTAINERS, ROLE_IDS.MODERATORS],
+    firstName: 'Shaun',
+    lastName: 'Smith',
+    googleEmailPrefix: 'shaun.smith',
+    memberOf: [
+      ROLE_IDS.COMMUNITY_MANAGERS,
+      ROLE_IDS.DOCS_MAINTAINERS,
+      ROLE_IDS.MAINTAINERS,
+      ROLE_IDS.MODERATORS,
+    ],
   },
   {
     github: 'fabpot',
@@ -194,8 +277,19 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.GO_SDK],
   },
   {
+    github: 'guglielmo-san',
+    discord: '1432786987072622613',
+    memberOf: [ROLE_IDS.GO_SDK],
+  },
+  {
     github: 'halter73',
-    memberOf: [ROLE_IDS.CSHARP_SDK],
+    discord: '340718902096953344',
+    memberOf: [ROLE_IDS.CSHARP_SDK, ROLE_IDS.CSHARP_SDK_ADMIN],
+  },
+  {
+    github: 'herczyn',
+    discord: '1001427188068917279',
+    memberOf: [ROLE_IDS.GO_SDK],
   },
   {
     github: 'idosal',
@@ -215,18 +309,22 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.RUST_SDK],
   },
   {
+    github: 'JAORMX',
+    discord: '1185152774674055193',
+    memberOf: [ROLE_IDS.SKILLS_OVER_MCP_IG],
+  },
+  {
     github: 'jba',
     discord: '773276903364755518',
     memberOf: [ROLE_IDS.GO_SDK],
   },
   {
-    github: 'jenn-newton',
-    memberOf: [ROLE_IDS.SECURITY_WG],
+    github: 'jeffhandley',
+    memberOf: [ROLE_IDS.CSHARP_SDK, ROLE_IDS.CSHARP_SDK_ADMIN],
   },
   {
-    github: 'jerome3o-anthropic',
-    discord: '222246825397059585',
-    memberOf: [ROLE_IDS.MODERATORS],
+    github: 'jenn-newton',
+    memberOf: [ROLE_IDS.SECURITY_WG],
   },
   {
     github: 'joan-anthropic',
@@ -234,19 +332,38 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.MCPB_MAINTAINERS],
   },
   {
+    github: 'jokemanfire',
+    memberOf: [ROLE_IDS.RUST_SDK],
+  },
+  {
     github: 'jonathanhefner',
     discord: '1301960963087663186',
     memberOf: [
+      ROLE_IDS.COMMUNITY_MANAGERS,
       ROLE_IDS.DOCS_MAINTAINERS,
+      ROLE_IDS.MAINTAINERS,
       ROLE_IDS.MODERATORS,
       ROLE_IDS.RUBY_SDK,
       ROLE_IDS.MCP_APPS_SDK,
     ],
   },
   {
+    github: 'jozkee',
+    memberOf: [ROLE_IDS.CSHARP_SDK],
+  },
+  {
     github: 'jspahrsummers',
     email: 'justin@modelcontextprotocol.io',
-    memberOf: [ROLE_IDS.CORE_MAINTAINERS],
+    firstName: 'Justin',
+    lastName: 'Spahr-Summers',
+    googleEmailPrefix: 'justin',
+    existingGWSUser: true,
+    memberOf: [ROLE_IDS.LEAD_MAINTAINERS, ROLE_IDS.CORE_MAINTAINERS],
+  },
+  {
+    github: 'kaxil',
+    discord: '757355088946921474',
+    memberOf: [ROLE_IDS.SKILLS_OVER_MCP_IG],
   },
   {
     github: 'Kehrlann',
@@ -254,9 +371,17 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.JAVA_SDK],
   },
   {
+    github: 'keithagroves',
+    discord: '321019863260987392',
+    memberOf: [ROLE_IDS.SKILLS_OVER_MCP_IG],
+  },
+  {
     github: 'KKonstantinov',
     discord: '390932438903422987',
-    memberOf: [ROLE_IDS.INSPECTOR_MAINTAINERS, ROLE_IDS.TYPESCRIPT_SDK],
+    memberOf: [ROLE_IDS.INSPECTOR_MAINTAINERS, ROLE_IDS.MAINTAINERS, ROLE_IDS.TYPESCRIPT_SDK],
+    firstName: 'Konstantin',
+    lastName: 'Konstantinov',
+    googleEmailPrefix: 'konstantin',
   },
   {
     github: 'Kludex',
@@ -275,6 +400,7 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'kurtisvg',
     discord: '1158458388917780590',
+    skipGoogleUserProvisioning: true,
     memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.TRANSPORT_WG],
   },
   {
@@ -285,16 +411,33 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'localden',
     discord: '1351224014143754260',
+    firstName: 'Den',
+    lastName: 'Delimarsky',
+    googleEmailPrefix: 'den',
+    existingGWSUser: true,
     memberOf: [
-      ROLE_IDS.AUTH_WG,
+      ROLE_IDS.AUTH_MAINTAINERS,
       ROLE_IDS.CORE_MAINTAINERS,
-      ROLE_IDS.CSHARP_SDK,
+      ROLE_IDS.LEAD_MAINTAINERS,
       ROLE_IDS.DOCS_MAINTAINERS,
+      ROLE_IDS.CSHARP_SDK_ADMIN,
+      ROLE_IDS.ADMINISTRATORS,
+      ROLE_IDS.GO_SDK,
+      ROLE_IDS.FINANCIAL_SERVICES_IG,
+      ROLE_IDS.MODERATORS,
+      ROLE_IDS.PHP_SDK,
+      ROLE_IDS.PYTHON_SDK,
+      ROLE_IDS.SECURITY_WG,
+      ROLE_IDS.TRANSPORT_WG,
+      ROLE_IDS.TYPESCRIPT_SDK,
     ],
   },
   {
     github: 'LucaButBoring',
     discord: '1366470072729866252',
+    firstName: 'Luca',
+    lastName: 'Chang',
+    googleEmailPrefix: 'luca',
     memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.AGENTS_IG, ROLE_IDS.WORKING_GROUPS],
   },
   {
@@ -308,10 +451,6 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.COMMUNITY_MANAGERS],
   },
   {
-    github: 'maheshmurag',
-    memberOf: [ROLE_IDS.MODERATORS],
-  },
-  {
     github: 'markpollack',
     memberOf: [ROLE_IDS.JAVA_SDK],
   },
@@ -320,12 +459,9 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.MCPB_MAINTAINERS],
   },
   {
-    github: 'mattt',
-    memberOf: [ROLE_IDS.SWIFT_SDK],
-  },
-  {
     github: 'mattzcarey',
-    memberOf: [ROLE_IDS.TYPESCRIPT_SDK],
+    discord: '224878268275359744',
+    memberOf: [ROLE_IDS.TYPESCRIPT_SDK, ROLE_IDS.TOOL_ANNOTATIONS_IG, ROLE_IDS.WG_IG_FACILITATORS],
   },
   {
     github: 'maxisbey',
@@ -339,10 +475,11 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'mikekistler',
     discord: '915345005982408754',
-    memberOf: [ROLE_IDS.CSHARP_SDK],
+    memberOf: [ROLE_IDS.CSHARP_SDK, ROLE_IDS.CSHARP_SDK_ADMIN],
   },
   {
     github: 'movetz',
+    discord: '1427569183427919906',
     memberOf: [ROLE_IDS.SWIFT_SDK],
   },
   {
@@ -353,6 +490,9 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'nickcoai',
     discord: '1153783469860732968',
+    firstName: 'Nick',
+    lastName: 'Cooper',
+    googleEmailPrefix: 'nickc',
     memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.SERVER_IDENTITY_WG],
   },
   {
@@ -382,11 +522,18 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'olaservo',
     discord: '1079841769946095620',
+    firstName: 'Ola',
+    lastName: 'Hungerford',
+    googleEmailPrefix: 'ola',
     memberOf: [
       ROLE_IDS.COMMUNITY_MANAGERS,
       ROLE_IDS.DOCS_MAINTAINERS,
       ROLE_IDS.INSPECTOR_MAINTAINERS,
+      ROLE_IDS.MAINTAINERS,
       ROLE_IDS.MODERATORS,
+      ROLE_IDS.REFERENCE_SERVERS_MAINTAINERS,
+      ROLE_IDS.SKILLS_OVER_MCP_IG,
+      ROLE_IDS.WORKING_GROUPS,
     ],
   },
   {
@@ -396,19 +543,32 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'pcarleton',
     discord: '1354465170969067852',
+    firstName: 'Paul',
+    lastName: 'Carleton',
+    googleEmailPrefix: 'paul',
+    existingGWSUser: true,
     memberOf: [
       ROLE_IDS.CORE_MAINTAINERS,
+      ROLE_IDS.DOCS_MAINTAINERS,
+      ROLE_IDS.ADMINISTRATORS,
+      ROLE_IDS.MODERATORS,
       ROLE_IDS.PYTHON_SDK,
       ROLE_IDS.PYTHON_SDK_AUTH,
       ROLE_IDS.TYPESCRIPT_SDK,
       ROLE_IDS.TYPESCRIPT_SDK_AUTH,
-      ROLE_IDS.AUTH_WG,
+      ROLE_IDS.AUTH_MAINTAINERS,
     ],
   },
   {
     github: 'pederhp',
     discord: '166255967665651713',
-    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.FINANCIAL_SERVICES_IG],
+    memberOf: [
+      ROLE_IDS.COMMUNITY_MANAGERS,
+      ROLE_IDS.MAINTAINERS,
+      ROLE_IDS.FINANCIAL_SERVICES_IG,
+      ROLE_IDS.MODERATORS,
+      ROLE_IDS.SKILLS_OVER_MCP_IG,
+    ],
   },
   {
     github: 'petery-ant',
@@ -417,7 +577,21 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'pja-ant',
     discord: '328628782497923072',
-    memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.MAINTAINERS, ROLE_IDS.TRANSPORT_WG],
+    firstName: 'Peter',
+    lastName: 'Alexander',
+    googleEmailPrefix: 'pja',
+    existingGWSUser: true,
+    memberOf: [
+      ROLE_IDS.CORE_MAINTAINERS,
+      ROLE_IDS.MAINTAINERS,
+      ROLE_IDS.SKILLS_OVER_MCP_IG,
+      ROLE_IDS.TRANSPORT_WG,
+      ROLE_IDS.TRIGGERS_EVENTS_WG,
+    ],
+  },
+  {
+    github: 'poteat',
+    memberOf: [ROLE_IDS.TYPESCRIPT_SDK_COLLABORATORS],
   },
   {
     github: 'pronskiy',
@@ -426,27 +600,58 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'pwwpche',
     discord: '1226238847013228604',
+    skipGoogleUserProvisioning: true,
     memberOf: [ROLE_IDS.CORE_MAINTAINERS],
   },
   {
     github: 'rdimitrov',
     email: 'radoslav@modelcontextprotocol.io',
     discord: '1088231882979815424',
-    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.REGISTRY_MAINTAINERS],
+    firstName: 'Radoslav',
+    lastName: 'Dimitrov',
+    googleEmailPrefix: 'radoslav',
+    existingGWSUser: true,
+    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.REGISTRY_MAINTAINERS, ROLE_IDS.SKILLS_OVER_MCP_IG],
+  },
+  {
+    github: 'rreichel3',
+    discord: '1458485333757788273',
+    memberOf: [ROLE_IDS.TOOL_ANNOTATIONS_IG, ROLE_IDS.WG_IG_FACILITATORS],
   },
   {
     github: 'sambhav',
     email: 'sambhavs.email@gmail.com',
+    firstName: 'Sambhav',
+    lastName: 'Kothari',
+    googleEmailPrefix: 'sambhav',
     discord: '840109459212206090',
     memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.FINANCIAL_SERVICES_IG],
   },
   {
-    github: 'samthanawalla',
-    memberOf: [ROLE_IDS.GO_SDK],
+    github: 'SamMorrowDrums',
+    email: 'sammorrowdrums@github.com',
+    discord: '782948163694493696',
+    firstName: 'Sam',
+    lastName: 'Morrow',
+    googleEmailPrefix: 'sam',
+    memberOf: [
+      ROLE_IDS.MAINTAINERS,
+      ROLE_IDS.PRIMITIVE_GROUPING_IG,
+      ROLE_IDS.SERVER_CARD_WG,
+      ROLE_IDS.SKILLS_OVER_MCP_IG,
+      ROLE_IDS.TOOL_ANNOTATIONS_IG,
+      ROLE_IDS.WG_IG_FACILITATORS,
+    ],
   },
   {
     github: 'sdubov',
     memberOf: [ROLE_IDS.KOTLIN_SDK],
+  },
+  {
+    github: 'soyuka',
+    email: 'soyuka@gmail.com',
+    discord: '249323948842418186',
+    memberOf: [ROLE_IDS.PHP_SDK],
   },
   {
     github: 'stallent',
@@ -455,12 +660,21 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'stephentoub',
-    memberOf: [ROLE_IDS.CSHARP_SDK],
+    memberOf: [ROLE_IDS.CSHARP_SDK, ROLE_IDS.CSHARP_SDK_ADMIN],
+  },
+  {
+    github: 'sunishsheth2009',
+    discord: '1414713222224941097',
+    memberOf: [ROLE_IDS.SKILLS_OVER_MCP_IG],
   },
   {
     github: 'tadasant',
     email: 'tadas@modelcontextprotocol.io',
     discord: '400092503677599754',
+    firstName: 'Tadas',
+    lastName: 'Antanavicius',
+    googleEmailPrefix: 'tadas',
+    existingGWSUser: true,
     memberOf: [
       ROLE_IDS.COMMUNITY_MANAGERS,
       ROLE_IDS.MODERATORS,
@@ -469,17 +683,31 @@ export const MEMBERS: readonly Member[] = [
       ROLE_IDS.INTEREST_GROUPS,
       ROLE_IDS.REGISTRY_MAINTAINERS,
       ROLE_IDS.ADMINISTRATORS,
+      ROLE_IDS.SERVER_CARD_WG,
     ],
+  },
+  {
+    github: 'tarekgh',
+    memberOf: [ROLE_IDS.CSHARP_SDK],
   },
   {
     github: 'tiginamaria',
     memberOf: [ROLE_IDS.KOTLIN_SDK],
   },
   {
+    github: 'tobinsouth',
+    discord: '865072069779521556',
+    memberOf: [ROLE_IDS.REFERENCE_SERVERS_MAINTAINERS],
+  },
+  {
     github: 'toby',
     email: 'toby@modelcontextprotocol.io',
     discord: '560155411777323048',
-    memberOf: [ROLE_IDS.REGISTRY_MAINTAINERS],
+    firstName: 'Toby',
+    lastName: 'Padilla',
+    googleEmailPrefix: 'toby',
+    existingGWSUser: true,
+    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.REGISTRY_MAINTAINERS],
   },
   {
     github: 'topherbullock',
@@ -490,6 +718,11 @@ export const MEMBERS: readonly Member[] = [
     github: 'tzolov',
     discord: '1097924660055777290',
     memberOf: [ROLE_IDS.DOCS_MAINTAINERS, ROLE_IDS.JAVA_SDK],
+  },
+  {
+    github: 'yarolegovich',
+    discord: '393296640141950977',
+    memberOf: [ROLE_IDS.GO_SDK],
   },
   {
     email: 'adamj@anthropic.com',

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -15,6 +15,16 @@ export interface Member {
   discord?: string;
   /** Roles this member belongs to */
   memberOf: readonly RoleId[];
+  /** First name (required for Google Workspace user provisioning) */
+  firstName?: string;
+  /** Last name (required for Google Workspace user provisioning) */
+  lastName?: string;
+  /** Google Workspace email prefix (e.g., 'david' -> david@modelcontextprotocol.io) */
+  googleEmailPrefix?: string;
+  /** If true, this user already exists in Google Workspace and should be imported into Pulumi state */
+  existingGWSUser?: boolean;
+  /** Explicitly skip automatic GWS user provisioning for provisionUser roles */
+  skipGoogleUserProvisioning?: boolean;
 }
 
 /**

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -20,31 +20,93 @@ interface DiscordApiError {
   message: string;
 }
 
+interface DiscordRateLimitResponse {
+  message: string;
+  retry_after: number;
+  global: boolean;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Cloudflare 5xx and edge-level 429s return plain-text bodies ("upstream connect
+// error...", "error code: 1015") that crash a naive response.json().
+function tryParseJson<T>(text: string): T | undefined {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined;
+  }
+}
+
 async function discordFetch<T>(
   token: string,
   endpoint: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  maxRetries = 10
 ): Promise<T> {
-  const response = await fetch(`${DISCORD_API_BASE}${endpoint}`, {
-    ...options,
-    headers: {
-      Authorization: `Bot ${token}`,
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-  });
+  let lastError: Error | undefined;
 
-  if (!response.ok) {
-    const error = (await response.json()) as DiscordApiError;
-    throw new Error(`Discord API error: ${error.message} (code: ${error.code})`);
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(`${DISCORD_API_BASE}${endpoint}`, {
+      ...options,
+      headers: {
+        Authorization: `Bot ${token}`,
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    });
+
+    if (response.status === 429) {
+      const text = await response.text();
+      const body = tryParseJson<DiscordRateLimitResponse>(text);
+      const retryAfterSec = body?.retry_after ?? 1;
+      // Linearly increasing jitter de-syncs the thundering herd when many
+      // resources refresh in parallel and all receive the same retry_after.
+      const jitterMs = Math.random() * 1000 * (attempt + 1);
+      const retryAfterMs = Math.ceil(retryAfterSec * 1000) + jitterMs;
+      lastError = new Error(
+        `Discord API rate limited on ${endpoint} (retry_after=${retryAfterSec}s, global=${body?.global ?? false})`
+      );
+      if (attempt < maxRetries) {
+        await sleep(retryAfterMs);
+        continue;
+      }
+      throw lastError;
+    }
+
+    if (response.status >= 500 && response.status < 600) {
+      const text = await response.text();
+      lastError = new Error(`Discord API ${response.status} on ${endpoint}: ${text.slice(0, 200)}`);
+      if (attempt < maxRetries) {
+        await sleep(2 ** attempt * 500 + Math.random() * 1000);
+        continue;
+      }
+      throw lastError;
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      const error = tryParseJson<DiscordApiError>(text);
+      throw new Error(
+        error
+          ? `Discord API error: ${error.message} (code: ${error.code})`
+          : `Discord API ${response.status} on ${endpoint}: ${text.slice(0, 200)}`
+      );
+    }
+
+    // Handle 204 No Content
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
   }
 
-  // Handle 204 No Content
-  if (response.status === 204) {
-    return undefined as T;
-  }
-
-  return response.json() as Promise<T>;
+  throw (
+    lastError ?? new Error(`Discord API request to ${endpoint} failed after ${maxRetries} retries`)
+  );
 }
 
 // Discord API response types
@@ -122,8 +184,8 @@ const discordRoleProvider: pulumi.dynamic.ResourceProvider = {
           roleId: role.id,
         },
       };
-    } catch {
-      throw new Error(`Failed to read role ${id}`);
+    } catch (error) {
+      throw new Error(`Failed to read role ${id}: ${error}`);
     }
   },
 
@@ -303,7 +365,7 @@ const discordMemberRoleSyncProvider: pulumi.dynamic.ResourceProvider = {
           },
         };
       }
-      throw new Error(`Failed to read member roles for ${id}`);
+      throw new Error(`Failed to read member roles for ${id}: ${error}`);
     }
 
     const currentRoles = new Set(member.roles);

--- a/src/google.ts
+++ b/src/google.ts
@@ -1,4 +1,7 @@
+import * as crypto from 'crypto';
+import * as pulumi from '@pulumi/pulumi';
 import * as gworkspace from '@pulumi/googleworkspace';
+import * as random from '@pulumi/random';
 import { ROLES, type Role, buildRoleLookup } from './config/roles';
 import { MEMBERS } from './config/users';
 import type { RoleId } from './config/roleIds';
@@ -45,20 +48,132 @@ ROLES.forEach((role: Role) => {
   });
 });
 
+// Create the organizational unit for MCP users
+const mcpOrgUnit = new gworkspace.OrgUnit(
+  'mcp-org-unit',
+  {
+    name: 'Model Context Protocol',
+    description: 'Model Context Protocol',
+    parentOrgUnitPath: '/',
+  },
+  { import: 'id:03ph8a2z0nc6rsr', ignoreChanges: ['description'] }
+);
+
+// Provision Google Workspace user accounts for members in roles with provisionUser
+const provisionedUsersByEmail: Record<string, gworkspace.User> = {};
+const newUserPasswords: Record<string, pulumi.Output<string>> = {};
+
+MEMBERS.forEach((member) => {
+  if (
+    !member.firstName ||
+    !member.lastName ||
+    !member.googleEmailPrefix ||
+    member.skipGoogleUserProvisioning
+  )
+    return;
+
+  const needsUser = member.memberOf.some((roleId: RoleId) => {
+    const role = roleLookup.get(roleId);
+    return role?.google?.provisionUser === true;
+  });
+  if (!needsUser) return;
+
+  const primaryEmail = `${member.googleEmailPrefix}@modelcontextprotocol.io`;
+
+  if (member.existingGWSUser) {
+    // Existing GWS users are not managed by Pulumi — the GWS provider's import
+    // validation rejects empty email types that GWS itself sets on primary/alias
+    // emails, and there's no way to fix this at the provider level.
+    // Group memberships for these users are created without dependsOn since the
+    // user already exists in GWS.
+    return;
+  } else {
+    // Create new user with random password
+    const password = new random.RandomPassword(`gws-pwd-${member.googleEmailPrefix}`, {
+      length: 24,
+      special: true,
+    });
+    const hashedPassword = password.result.apply((plaintext: string) =>
+      crypto.createHash('sha1').update(plaintext).digest('hex')
+    );
+
+    const user = new gworkspace.User(
+      `gws-user-${member.googleEmailPrefix}`,
+      {
+        primaryEmail,
+        name: { familyName: member.lastName!, givenName: member.firstName! },
+        password: hashedPassword,
+        hashFunction: 'SHA-1',
+        changePasswordAtNextLogin: true,
+        orgUnitPath: mcpOrgUnit.orgUnitPath,
+      },
+      {
+        dependsOn: [mcpOrgUnit],
+        ignoreChanges: [
+          'recoveryEmail',
+          'recoveryPhone',
+          'password',
+          'hashFunction',
+          'changePasswordAtNextLogin',
+          'orgUnitPath',
+          'archived',
+          'suspended',
+          'isAdmin',
+          'includeInGlobalAddressList',
+          'ipAllowlist',
+          'addresses',
+          'aliases',
+          'customSchemas',
+          'emails',
+          'externalIds',
+          'ims',
+          'keywords',
+          'languages',
+          'locations',
+          'organizations',
+          'phones',
+          'posixAccounts',
+          'relations',
+          'sshPublicKeys',
+          'websites',
+          'name',
+        ],
+      }
+    );
+    provisionedUsersByEmail[primaryEmail] = user;
+
+    // Track password for export so an admin can retrieve it
+    newUserPasswords[primaryEmail] = password.result;
+  }
+});
+
 // Create group memberships for users
 MEMBERS.forEach((member) => {
-  if (!member.email) return;
+  // Prefer the provisioned GWS email over the personal email for group memberships
+  const gwsEmail = member.googleEmailPrefix
+    ? `${member.googleEmailPrefix}@modelcontextprotocol.io`
+    : undefined;
+  const memberEmail = gwsEmail || member.email;
+  if (!memberEmail) return;
+  const provisionedUser = gwsEmail ? provisionedUsersByEmail[gwsEmail] : undefined;
 
   member.memberOf.forEach((roleId: RoleId) => {
     const role = roleLookup.get(roleId);
     if (!role?.google) return; // Role doesn't have Google config
 
-    new gworkspace.GroupMember(`${member.email}-${role.google.group}`, {
-      groupId: groups[role.google.group].id,
-      email: member.email!,
-      role: 'MEMBER',
-    });
+    new gworkspace.GroupMember(
+      `${memberEmail}-${role.google.group}`,
+      {
+        groupId: groups[role.google.group].id,
+        email: memberEmail,
+        role: 'MEMBER',
+      },
+      provisionedUser ? { dependsOn: [provisionedUser] } : undefined
+    );
   });
 });
 
 export { groups as googleGroups };
+// Export initial passwords as secrets so an admin can retrieve them with:
+//   pulumi stack output --show-secrets newGWSUserPasswords
+export const newGWSUserPasswords = pulumi.secret(newUserPasswords);


### PR DESCRIPTION
Add Google Workspace fields to provision `sam@modelcontextprotocol.io` account.

## Changes

Added `firstName`, `lastName`, and `googleEmailPrefix` to the existing `SamMorrowDrums` entry in `src/config/users.ts`, following the same pattern as other members (e.g., `olaservo`).

The `MAINTAINERS` role already has `provisionUser: true`, so the account will be provisioned on merge.

## Context

Approved by @dsp — need Google Workspace access for creating recorded calls etc. (non-admin).