### PR TITLE
feat: add Google Workspace account for SamMorrowDrums

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -631,6 +631,9 @@ export const MEMBERS: readonly Member[] = [
     github: 'SamMorrowDrums',
     email: 'sammorrowdrums@github.com',
     discord: '782948163694493696',
+    firstName: 'Sam',
+    lastName: 'Morrow',
+    googleEmailPrefix: 'sam',
     memberOf: [
       ROLE_IDS.MAINTAINERS,
       ROLE_IDS.PRIMITIVE_GROUPING_IG,


### PR DESCRIPTION
Add Google Workspace fields to provision `sam@modelcontextprotocol.io` account.

## Changes

Added `firstName`, `lastName`, and `googleEmailPrefix` to the `SamMorrowDrums` entry in `src/config/users.ts`, following the same pattern as other members (e.g., `olaservo`).

The `MAINTAINERS` role already has `provisionUser: true`, so the account will be provisioned on merge.
