### PR TITLE
Add File Uploads Working Group

### DIFF
--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -56,6 +56,7 @@ export const ROLE_IDS = {
   MCP_APPS_WG: 'mcp-apps-wg',
   SERVER_CARD_WG: 'server-card-wg',
   INTERCEPTORS_WG: 'interceptors-wg',
+  FILE_UPLOADS_WG: 'file-uploads-wg',
 
   // ===================
   // Interest Groups

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -303,6 +303,12 @@ export const ROLES: readonly Role[] = [
     github: { team: 'interceptors-wg', parent: ROLE_IDS.WORKING_GROUPS },
     discord: { role: 'interceptors working group (synced)' },
   },
+  {
+    id: ROLE_IDS.FILE_UPLOADS_WG,
+    description: 'File Uploads Working Group',
+    github: { team: 'file-uploads-wg', parent: ROLE_IDS.WORKING_GROUPS },
+    discord: { role: 'file uploads working group (synced)' },
+  },
 
   // ===================
   // Interest Groups

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -430,6 +430,7 @@ export const MEMBERS: readonly Member[] = [
       ROLE_IDS.DOCS_MAINTAINERS,
       ROLE_IDS.CSHARP_SDK_ADMIN,
       ROLE_IDS.ADMINISTRATORS,
+      ROLE_IDS.FILE_UPLOADS_WG,
       ROLE_IDS.GO_SDK,
       ROLE_IDS.FINANCIAL_SERVICES_IG,
       ROLE_IDS.MODERATORS,
@@ -501,7 +502,7 @@ export const MEMBERS: readonly Member[] = [
     firstName: 'Nick',
     lastName: 'Cooper',
     googleEmailPrefix: 'nickc',
-    memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.SERVER_IDENTITY_WG],
+    memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.FILE_UPLOADS_WG, ROLE_IDS.SERVER_IDENTITY_WG],
   },
   {
     github: 'nicolas-grekas',
@@ -516,6 +517,7 @@ export const MEMBERS: readonly Member[] = [
     github: 'ochafik',
     discord: '1004897332069925024',
     memberOf: [
+      ROLE_IDS.FILE_UPLOADS_WG,
       ROLE_IDS.MCP_APPS_SDK,
       ROLE_IDS.PYTHON_SDK,
       ROLE_IDS.PYTHON_SDK_AUTH,


### PR DESCRIPTION
Provisions the `file-uploads-wg` GitHub team (parented under `working-groups`) and the matching synced Discord role for the new File Uploads Working Group.

Initial members are `@localden` (Lead), `@nickcoai`, and `@ochafik`, matching the membership table in the charter at modelcontextprotocol/modelcontextprotocol#2635. The WG drives [SEP-2356 (declarative file inputs)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2356).