### PR TITLE
Add caseychow-oai to File Uploads WG

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -85,6 +85,10 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.TRANSPORT_WG],
   },
   {
+    github: 'caseychow-oai',
+    memberOf: [ROLE_IDS.FILE_UPLOADS_WG],
+  },
+  {
     github: 'chemicL',
     discord: '1346243721271971923',
     memberOf: [ROLE_IDS.JAVA_SDK],


### PR DESCRIPTION
Follow-up to #104 — adds [@caseychow-oai](https://github.com/caseychow-oai) (Casey Chow) to the File Uploads Working Group.

Casey is the author of [SEP-2631: File Objects and Transfer](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2631).