### PR TITLE
Manage GitHub org settings and org-role assignments via Pulumi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           PULUMI_PASSPHRASE: ${{ secrets.PULUMI_PROD_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.PULUMI_GITHUB_TOKEN }}
+          ORG_BILLING_EMAIL: ${{ secrets.ORG_BILLING_EMAIL }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
         run: |
@@ -71,4 +72,5 @@ jobs:
           pulumi login gs://mcp-access-prod-pulumi-state
           pulumi config set discord:guildId "$DISCORD_GUILD_ID" --stack prod
           pulumi config set discord:botToken "$DISCORD_BOT_TOKEN" --secret --stack prod
+          pulumi config set github:billingEmail "$ORG_BILLING_EMAIL" --secret --stack prod
           make up

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,5 +72,5 @@ jobs:
           pulumi login gs://mcp-access-prod-pulumi-state
           pulumi config set discord:guildId "$DISCORD_GUILD_ID" --stack prod
           pulumi config set discord:botToken "$DISCORD_BOT_TOKEN" --secret --stack prod
-          pulumi config set github:billingEmail "$ORG_BILLING_EMAIL" --secret --stack prod
+          pulumi config set githubBillingEmail "$ORG_BILLING_EMAIL" --secret --stack prod
           make up

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -79,7 +79,7 @@ jobs:
             CONFIG_FLAGS="$CONFIG_FLAGS --config discord:botToken=$DISCORD_BOT_TOKEN"
           fi
           if [ -n "$ORG_BILLING_EMAIL" ]; then
-            PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi config set github:billingEmail "$ORG_BILLING_EMAIL" --secret --stack prod
+            CONFIG_FLAGS="$CONFIG_FLAGS --config githubBillingEmail=$ORG_BILLING_EMAIL"
           fi
 
           # Run preview and capture output

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           PULUMI_PASSPHRASE: ${{ secrets.PULUMI_PROD_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.PULUMI_GITHUB_TOKEN }}
+          ORG_BILLING_EMAIL: ${{ secrets.ORG_BILLING_EMAIL }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
         run: |
@@ -76,6 +77,9 @@ jobs:
           fi
           if [ -n "$DISCORD_BOT_TOKEN" ]; then
             CONFIG_FLAGS="$CONFIG_FLAGS --config discord:botToken=$DISCORD_BOT_TOKEN"
+          fi
+          if [ -n "$ORG_BILLING_EMAIL" ]; then
+            PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi config set github:billingEmail "$ORG_BILLING_EMAIL" --secret --stack prod
           fi
 
           # Run preview and capture output

--- a/src/config/orgRoles.ts
+++ b/src/config/orgRoles.ts
@@ -1,0 +1,23 @@
+// GitHub organization-level role assignments.
+// These grant a base permission across ALL repositories in the org via GitHub's
+// pre-defined organization roles, independent of per-repo collaborators in repoAccess.ts.
+// See https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/using-organization-roles
+
+export type OrgRoleName =
+  | 'all_repo_read'
+  | 'all_repo_triage'
+  | 'all_repo_write'
+  | 'all_repo_maintain'
+  | 'all_repo_admin';
+
+export interface OrgRoleAssignment {
+  /** GitHub team slug */
+  team: string;
+  /** Pre-defined GitHub organization role name */
+  role: OrgRoleName;
+}
+
+export const ORG_ROLE_ASSIGNMENTS: OrgRoleAssignment[] = [
+  { team: 'lead-maintainers', role: 'all_repo_admin' },
+  { team: 'core-maintainers', role: 'all_repo_admin' },
+];

--- a/src/config/orgSettings.ts
+++ b/src/config/orgSettings.ts
@@ -6,7 +6,7 @@
 
 // billingEmail is required by the provider but intentionally omitted here so it
 // is not committed to a public repo. It is read from Pulumi config in github.ts:
-//   pulumi config set --secret github:billingEmail <email>
+//   pulumi config set --secret githubBillingEmail <email>
 export const ORG_SETTINGS = {
   name: 'Model Context Protocol',
   description:

--- a/src/config/orgSettings.ts
+++ b/src/config/orgSettings.ts
@@ -1,0 +1,33 @@
+// GitHub organization-level settings.
+// Captured explicitly so changes go through review. Values mirror current state
+// except defaultRepositoryPermission, which is set to 'none' so private repos
+// (disclosures, community-moderators, GHSA forks) are not implicitly readable
+// by every org member. Explicit access flows from orgRoles.ts and repoAccess.ts.
+
+// billingEmail is required by the provider but intentionally omitted here so it
+// is not committed to a public repo. It is read from Pulumi config in github.ts:
+//   pulumi config set --secret github:billingEmail <email>
+export const ORG_SETTINGS = {
+  name: 'Model Context Protocol',
+  description:
+    'An open protocol that enables seamless integration between LLM applications and external data sources and tools.',
+  defaultRepositoryPermission: 'none',
+  hasOrganizationProjects: true,
+  hasRepositoryProjects: true,
+  membersCanCreateRepositories: false,
+  membersCanCreatePublicRepositories: false,
+  membersCanCreatePrivateRepositories: false,
+  membersCanCreatePages: false,
+  membersCanCreatePublicPages: false,
+  membersCanCreatePrivatePages: false,
+  membersCanForkPrivateRepositories: false,
+  webCommitSignoffRequired: false,
+  // Provider defaults the following to `false` if omitted, which would silently
+  // disable org-wide security features that are currently on.
+  advancedSecurityEnabledForNewRepositories: true,
+  dependabotAlertsEnabledForNewRepositories: true,
+  dependabotSecurityUpdatesEnabledForNewRepositories: true,
+  dependencyGraphEnabledForNewRepositories: true,
+  secretScanningEnabledForNewRepositories: true,
+  secretScanningPushProtectionEnabledForNewRepositories: true,
+} as const;

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,9 +1,25 @@
+import * as pulumi from '@pulumi/pulumi';
 import * as github from '@pulumi/github';
 import { ROLES, type Role, buildRoleLookup } from './config/roles';
 import { REPOSITORY_ACCESS } from './config/repoAccess';
+import { ORG_ROLE_ASSIGNMENTS } from './config/orgRoles';
+import { ORG_SETTINGS } from './config/orgSettings';
 import { MEMBERS } from './config/users';
 import { sortRolesByGitHubDependency } from './config/utils';
 import type { RoleId } from './config/roleIds';
+
+const githubConfig = new pulumi.Config('github');
+
+// The provider's Create for this resource is a PATCH on the existing org, so
+// no import is needed; first apply writes the values below directly.
+new github.OrganizationSettings(
+  'org-settings',
+  {
+    ...ORG_SETTINGS,
+    billingEmail: githubConfig.requireSecret('billingEmail'),
+  },
+  { additionalSecretOutputs: ['billingEmail'] }
+);
 
 const roleLookup = buildRoleLookup();
 // Teams keyed by GitHub team name (matches repoAccess.ts references)
@@ -47,6 +63,26 @@ MEMBERS.forEach((member) => {
       username: member.github!,
       role: 'member',
     });
+  });
+});
+
+// Assign organization-level roles to teams (grants access across all repos)
+const orgRoles = github.getOrganizationRolesOutput();
+ORG_ROLE_ASSIGNMENTS.forEach((assignment) => {
+  const team = teams[assignment.team];
+  if (!team) {
+    throw new Error(
+      `orgRoles.ts references team '${assignment.team}' which is not managed in roles.ts`
+    );
+  }
+  const roleId = orgRoles.roles.apply((roles) => {
+    const match = roles.find((r) => r.name === assignment.role);
+    if (!match) throw new Error(`Organization role '${assignment.role}' not found`);
+    return match.roleId;
+  });
+  new github.OrganizationRoleTeam(`orgrole-${assignment.team}-${assignment.role}`, {
+    teamSlug: team.slug,
+    roleId,
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -8,7 +8,7 @@ import { MEMBERS } from './config/users';
 import { sortRolesByGitHubDependency } from './config/utils';
 import type { RoleId } from './config/roleIds';
 
-const githubConfig = new pulumi.Config('github');
+const config = new pulumi.Config();
 
 // The provider's Create for this resource is a PATCH on the existing org, so
 // no import is needed; first apply writes the values below directly.
@@ -16,7 +16,7 @@ new github.OrganizationSettings(
   'org-settings',
   {
     ...ORG_SETTINGS,
-    billingEmail: githubConfig.requireSecret('billingEmail'),
+    billingEmail: config.requireSecret('githubBillingEmail'),
   },
   { additionalSecretOutputs: ['billingEmail'] }
 );


### PR DESCRIPTION
Brings two click-ops org-level configs under IaC and tightens defaults.

**Org settings** (`src/config/orgSettings.ts`, new `github.OrganizationSettings` resource):
- `default_repository_permission`: `read` → `none` — private repos are no longer implicitly readable by every org member; access flows from org roles and `repoAccess.ts`
- Member repo/Pages creation: `true` → `false`
- Security new-repo defaults (secret scanning, Dependabot, GHAS) pinned explicitly so the provider doesn't reset them
- `billingEmail` is read from the new **`ORG_BILLING_EMAIL`** Actions secret (already configured) so it isn't committed to this public repo

**Org-role assignments** (`src/config/orgRoles.ts`, new `github.OrganizationRoleTeam` resources):
- Codifies `lead-maintainers` and `core-maintainers` → `all_repo_admin` (status quo)
- `moderators → all_repo_triage` and `anthropic → all_repo_write` are intentionally not codified — those grants are being removed separately