### PR TITLE
Suppress googleworkspace permadiffs in preview output

### DIFF
--- a/src/google.ts
+++ b/src/google.ts
@@ -20,32 +20,36 @@ ROLES.forEach((role: Role) => {
     description: role.description + ' \n(Managed by github.com/modelcontextprotocol/access)',
   });
 
-  new gworkspace.GroupSettings(role.google.group, {
-    email: groups[role.google.group].email,
+  new gworkspace.GroupSettings(
+    role.google.group,
+    {
+      email: groups[role.google.group].email,
 
-    // Maximise visibility of group. It's visible in GitHub anyway
-    whoCanViewMembership: 'ALL_IN_DOMAIN_CAN_VIEW',
+      // Maximise visibility of group. It's visible in GitHub anyway
+      whoCanViewMembership: 'ALL_IN_DOMAIN_CAN_VIEW',
 
-    // This specifies who can add/remove members. We want this to only be via this IaC.
-    whoCanModerateMembers: 'NONE',
-    whoCanLeaveGroup: 'NONE_CAN_LEAVE',
-    whoCanJoin: 'INVITED_CAN_JOIN',
+      // This specifies who can add/remove members. We want this to only be via this IaC.
+      whoCanModerateMembers: 'NONE',
+      whoCanLeaveGroup: 'NONE_CAN_LEAVE',
+      whoCanJoin: 'INVITED_CAN_JOIN',
 
-    // Email groups allow anyone (including externals) to post
-    // Non-email groups are not intended as mailing lists, so use the most restrictive settings
-    // whoCanViewGroup is badly named, but actually means 'Permissions to view group messages'. See https://developers.google.com/workspace/admin/groups-settings/v1/reference/groups
-    ...(role.google.isEmailGroup
-      ? {
-          whoCanPostMessage: 'ANYONE_CAN_POST',
-          whoCanContactOwner: 'ALL_OWNERS_CAN_CONTACT',
-          whoCanViewGroup: 'ALL_MEMBERS_CAN_VIEW',
-        }
-      : {
-          whoCanPostMessage: 'ALL_OWNERS_CAN_POST',
-          whoCanContactOwner: 'ALL_OWNERS_CAN_CONTACT',
-          whoCanViewGroup: 'ALL_OWNERS_CAN_VIEW',
-        }),
-  });
+      // Email groups allow anyone (including externals) to post
+      // Non-email groups are not intended as mailing lists, so use the most restrictive settings
+      // whoCanViewGroup is badly named, but actually means 'Permissions to view group messages'. See https://developers.google.com/workspace/admin/groups-settings/v1/reference/groups
+      ...(role.google.isEmailGroup
+        ? {
+            whoCanPostMessage: 'ANYONE_CAN_POST',
+            whoCanContactOwner: 'ALL_OWNERS_CAN_CONTACT',
+            whoCanViewGroup: 'ALL_MEMBERS_CAN_VIEW',
+          }
+        : {
+            whoCanPostMessage: 'ALL_OWNERS_CAN_POST',
+            whoCanContactOwner: 'ALL_OWNERS_CAN_CONTACT',
+            whoCanViewGroup: 'ALL_OWNERS_CAN_VIEW',
+          }),
+    },
+    { ignoreChanges: ['isArchived'] }
+  );
 });
 
 // Create the organizational unit for MCP users
@@ -56,7 +60,7 @@ const mcpOrgUnit = new gworkspace.OrgUnit(
     description: 'Model Context Protocol',
     parentOrgUnitPath: '/',
   },
-  { import: 'id:03ph8a2z0nc6rsr', ignoreChanges: ['description'] }
+  { ignoreChanges: ['description'] }
 );
 
 // Provision Google Workspace user accounts for members in roles with provisionUser


### PR DESCRIPTION
Every `pulumi preview` currently reports 7 `GroupSettings` and 1 `OrgUnit` as updates with no actual field changes, which buries real diffs.

- **GroupSettings**: add `ignoreChanges: ['isArchived']` — known upstream permadiff ([hashicorp/terraform-provider-googleworkspace#398](https://github.com/hashicorp/terraform-provider-googleworkspace/issues/398))
- **OrgUnit**: drop the stale `import:` option that was only needed for the initial adopt

No behavioral change; preview output only.