### PR TITLE
feat: add Agents Working Group with experimental-ext-tasks access

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -346,6 +346,14 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     ],
   },
   {
+    repository: 'experimental-ext-tasks',
+    teams: [
+      { team: 'core-maintainers', permission: 'admin' },
+      { team: 'moderators', permission: 'maintain' },
+      { team: 'agents-wg', permission: 'admin' },
+    ],
+  },
+  {
     repository: 'maintainer-docs',
     teams: [
       { team: 'lead-maintainers', permission: 'maintain' },

--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -57,6 +57,7 @@ export const ROLE_IDS = {
   SERVER_CARD_WG: 'server-card-wg',
   INTERCEPTORS_WG: 'interceptors-wg',
   FILE_UPLOADS_WG: 'file-uploads-wg',
+  AGENTS_WG: 'agents-wg',
 
   // ===================
   // Interest Groups

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -309,6 +309,11 @@ export const ROLES: readonly Role[] = [
     github: { team: 'file-uploads-wg', parent: ROLE_IDS.WORKING_GROUPS },
     discord: { role: 'file uploads working group (synced)' },
   },
+  {
+    id: ROLE_IDS.AGENTS_WG,
+    description: 'Agents Working Group',
+    github: { team: 'agents-wg', parent: ROLE_IDS.WORKING_GROUPS },
+  },
 
   // ===================
   // Interest Groups

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -82,7 +82,7 @@ export const MEMBERS: readonly Member[] = [
     firstName: 'Caitie',
     lastName: 'McCaffrey',
     googleEmailPrefix: 'caitie',
-    memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.TRANSPORT_WG],
+    memberOf: [ROLE_IDS.CORE_MAINTAINERS, ROLE_IDS.TRANSPORT_WG, ROLE_IDS.AGENTS_WG],
   },
   {
     github: 'caseychow-oai',
@@ -233,6 +233,7 @@ export const MEMBERS: readonly Member[] = [
       ROLE_IDS.DOCS_MAINTAINERS,
       ROLE_IDS.MODERATORS,
       ROLE_IDS.SERVER_CARD_WG,
+      ROLE_IDS.AGENTS_WG,
     ],
   },
   {
@@ -464,7 +465,12 @@ export const MEMBERS: readonly Member[] = [
     firstName: 'Luca',
     lastName: 'Chang',
     googleEmailPrefix: 'luca',
-    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.AGENTS_IG, ROLE_IDS.WORKING_GROUPS],
+    memberOf: [
+      ROLE_IDS.MAINTAINERS,
+      ROLE_IDS.AGENTS_IG,
+      ROLE_IDS.AGENTS_WG,
+      ROLE_IDS.WORKING_GROUPS,
+    ],
   },
   {
     github: 'maciej-kisiel',
@@ -618,6 +624,7 @@ export const MEMBERS: readonly Member[] = [
       ROLE_IDS.SKILLS_OVER_MCP_IG,
       ROLE_IDS.TRANSPORT_WG,
       ROLE_IDS.TRIGGERS_EVENTS_WG,
+      ROLE_IDS.AGENTS_WG,
     ],
   },
   {


### PR DESCRIPTION
Creates the agents-wg role and corresponding GitHub team under working-groups, adds Caitie, David, Luca, and Peter Alexander as members, and grants the team admin access to the experimental-ext-tasks repository.
