### PR TITLE
feat: remove pwwpche from CORE_MAINTAINERS (moved to emeritus)

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -631,8 +631,7 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'pwwpche',
     discord: '1226238847013228604',
-    skipGoogleUserProvisioning: true,
-    memberOf: [ROLE_IDS.CORE_MAINTAINERS],
+    memberOf: [],
   },
   {
     github: 'rdimitrov',


### PR DESCRIPTION
Che Liu (`pwwpche`) is moving to Core Maintainer Emeritus.

- Removes `ROLE_IDS.CORE_MAINTAINERS` from `pwwpche` (now `memberOf: []`, entry kept to preserve discord ID)
- Drops the now-invalid `skipGoogleUserProvisioning: true` flag (no longer in a provisionUser role)

`npm run check` passes (23/23).

Companion docs change: modelcontextprotocol/modelcontextprotocol#2691