### PR TITLE
chore: align registry roster with WG charter

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -252,7 +252,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     repository: 'registry',
     teams: [
       { team: 'registry-wg', permission: 'admin' },
-      { team: 'registry-wg-collaborators', permission: 'push' },
+      { team: 'registry-collaborators', permission: 'push' },
     ],
   },
   {

--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -250,7 +250,10 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   },
   {
     repository: 'registry',
-    teams: [{ team: 'registry-wg', permission: 'admin' }],
+    teams: [
+      { team: 'registry-wg', permission: 'admin' },
+      { team: 'registry-wg-collaborators', permission: 'push' },
+    ],
   },
   {
     repository: 'static',

--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -22,6 +22,7 @@ export const ROLE_IDS = {
   MCPB_MAINTAINERS: 'mcpb-maintainers',
   REFERENCE_SERVERS_MAINTAINERS: 'reference-servers-maintainers',
   REGISTRY_MAINTAINERS: 'registry-maintainers',
+  REGISTRY_WG_COLLABORATORS: 'registry-wg-collaborators',
   USE_MCP_MAINTAINERS: 'use-mcp-maintainers',
 
   // ===================

--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -22,7 +22,7 @@ export const ROLE_IDS = {
   MCPB_MAINTAINERS: 'mcpb-maintainers',
   REFERENCE_SERVERS_MAINTAINERS: 'reference-servers-maintainers',
   REGISTRY_MAINTAINERS: 'registry-maintainers',
-  REGISTRY_WG_COLLABORATORS: 'registry-wg-collaborators', // GitHub only
+  REGISTRY_COLLABORATORS: 'registry-collaborators', // GitHub only
   USE_MCP_MAINTAINERS: 'use-mcp-maintainers',
 
   // ===================

--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -22,7 +22,7 @@ export const ROLE_IDS = {
   MCPB_MAINTAINERS: 'mcpb-maintainers',
   REFERENCE_SERVERS_MAINTAINERS: 'reference-servers-maintainers',
   REGISTRY_MAINTAINERS: 'registry-maintainers',
-  REGISTRY_WG_COLLABORATORS: 'registry-wg-collaborators',
+  REGISTRY_WG_COLLABORATORS: 'registry-wg-collaborators', // GitHub only
   USE_MCP_MAINTAINERS: 'use-mcp-maintainers',
 
   // ===================

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -139,9 +139,9 @@ export const ROLES: readonly Role[] = [
     google: { group: 'registry-wg', provisionUser: true },
   },
   {
-    id: ROLE_IDS.REGISTRY_WG_COLLABORATORS,
+    id: ROLE_IDS.REGISTRY_COLLABORATORS,
     description: 'Registry working group collaborators',
-    github: { team: 'registry-wg-collaborators', parent: ROLE_IDS.REGISTRY_MAINTAINERS },
+    github: { team: 'registry-collaborators', parent: ROLE_IDS.REGISTRY_MAINTAINERS },
   },
   {
     id: ROLE_IDS.USE_MCP_MAINTAINERS,

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -139,6 +139,14 @@ export const ROLES: readonly Role[] = [
     google: { group: 'registry-wg', provisionUser: true },
   },
   {
+    id: ROLE_IDS.REGISTRY_WG_COLLABORATORS,
+    description: 'Registry working group collaborators',
+    github: { team: 'registry-wg-collaborators', parent: ROLE_IDS.REGISTRY_MAINTAINERS },
+    discord: { role: 'registry collaborators (synced)' },
+    // Collaborators get push (not admin) on the registry repo and are not maintainers.
+    // Mirrors the typescript-sdk-collaborators model. No google config = no @modelcontextprotocol.io account.
+  },
+  {
     id: ROLE_IDS.USE_MCP_MAINTAINERS,
     description: 'use-mcp maintainers',
     discord: { role: 'use-mcp maintainers (synced)' },

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -142,9 +142,6 @@ export const ROLES: readonly Role[] = [
     id: ROLE_IDS.REGISTRY_WG_COLLABORATORS,
     description: 'Registry working group collaborators',
     github: { team: 'registry-wg-collaborators', parent: ROLE_IDS.REGISTRY_MAINTAINERS },
-    discord: { role: 'registry collaborators (synced)' },
-    // Collaborators get push (not admin) on the registry repo and are not maintainers.
-    // Mirrors the typescript-sdk-collaborators model. No google config = no @modelcontextprotocol.io account.
   },
   {
     id: ROLE_IDS.USE_MCP_MAINTAINERS,

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -198,7 +198,7 @@ export const MEMBERS: readonly Member[] = [
     lastName: 'Jones',
     googleEmailPrefix: 'adam',
     existingGWSUser: true,
-    memberOf: [ROLE_IDS.MCPB_MAINTAINERS, ROLE_IDS.REGISTRY_MAINTAINERS],
+    memberOf: [ROLE_IDS.MCPB_MAINTAINERS],
   },
   {
     github: 'dsp',
@@ -642,6 +642,13 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.CSHARP_SDK],
   },
   {
+    github: 'pree-dew',
+    discord: '1379733751315173376',
+    firstName: 'Preeti',
+    lastName: 'Dewani',
+    memberOf: [ROLE_IDS.REGISTRY_WG_COLLABORATORS],
+  },
+  {
     github: 'pronskiy',
     memberOf: [ROLE_IDS.PHP_SDK],
   },
@@ -745,16 +752,6 @@ export const MEMBERS: readonly Member[] = [
     github: 'tobinsouth',
     discord: '865072069779521556',
     memberOf: [ROLE_IDS.REFERENCE_SERVERS_MAINTAINERS],
-  },
-  {
-    github: 'toby',
-    email: 'toby@modelcontextprotocol.io',
-    discord: '560155411777323048',
-    firstName: 'Toby',
-    lastName: 'Padilla',
-    googleEmailPrefix: 'toby',
-    existingGWSUser: true,
-    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.REGISTRY_MAINTAINERS],
   },
   {
     github: 'topherbullock',

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -646,7 +646,7 @@ export const MEMBERS: readonly Member[] = [
     discord: '1379733751315173376',
     firstName: 'Preeti',
     lastName: 'Dewani',
-    memberOf: [ROLE_IDS.REGISTRY_WG_COLLABORATORS],
+    memberOf: [ROLE_IDS.REGISTRY_COLLABORATORS],
   },
   {
     github: 'pronskiy',

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -754,6 +754,17 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.REFERENCE_SERVERS_MAINTAINERS],
   },
   {
+    github: 'toby',
+    email: 'toby@modelcontextprotocol.io',
+    discord: '560155411777323048',
+    firstName: 'Toby',
+    lastName: 'Padilla',
+    googleEmailPrefix: 'toby',
+    existingGWSUser: true,
+    // Emeritus maintainer of the Registry
+    memberOf: [],
+  },
+  {
     github: 'topherbullock',
     discord: '1059910719124013168',
     memberOf: [ROLE_IDS.RUBY_SDK],


### PR DESCRIPTION
## Summary

Aligns GitHub access for the Registry with the new [Registry Working Group charter](https://modelcontextprotocol.io/community/registry/charter). Concretely, this introduces a non-maintainer collaborator tier for the registry (`registry-collaborators`), adds the first collaborator (Pree), and moves Toby and Adam to emeritus Registry maintainership.

## Changes

**New `registry-collaborators` GitHub team** (GitHub-only — no Discord or Google config)
- `roleIds.ts`: adds the `REGISTRY_COLLABORATORS` role id, annotated `// GitHub only` to match the `typescript-sdk-collaborators` convention.
- `roles.ts`: defines the role as a GitHub team nested under `registry-maintainers` (parent = `REGISTRY_MAINTAINERS`). Mirrors the `typescript-sdk-collaborators` model — push access, not admin, and no maintainer privileges.
- `repoAccess.ts`: grants the `registry-collaborators` team **push** access to the `registry` repo (the `registry-wg` maintainers team keeps **admin**).

**Membership updates** (`users.ts`)
- **Preeti (Pree) Dewani** ([@pree-dew](https://github.com/pree-dew)) — added as the first member of `registry-wg-collaborators`.
- **Adam Jones** ([@domdomegg](https://github.com/domdomegg)) — removed from `registry-maintainers`; he **remains** an MCPB maintainer (`mcpb-maintainers` retained, unchanged).
- **Toby Padilla** ([@toby](https://github.com/toby)) — removed from `maintainers` and `registry-maintainers`. His entry is retained with an empty `memberOf` and a `// Emeritus maintainer of the Registry` comment rather than being deleted. Because he is an `existingGWSUser`, no Google Workspace mailbox is created or removed.

## Notes

- **No Discord config** is added for collaborators — there is no corresponding Discord group.
- This is GitHub-team plumbing only; no Discord roles or Google groups are added or removed by this PR.

## Testing

- `npm test` → **23/23 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
