### PR TITLE
Add example-remote-server repository access

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -309,6 +309,15 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     ],
   },
   {
+    repository: 'example-remote-server',
+    teams: [
+      { team: 'core-maintainers', permission: 'push' },
+      { team: 'moderators', permission: 'maintain' },
+      { team: 'mcp-apps-wg', permission: 'push' },
+      { team: 'mcp-apps-sdk', permission: 'admin' },
+    ],
+  },
+  {
     repository: 'experimental-ext-grouping',
     teams: [
       { team: 'core-maintainers', permission: 'admin' },


### PR DESCRIPTION
## What & why

`example-remote-server` is missing from `repoAccess.ts`. Since the org's `defaultRepositoryPermission` is `none`, that means **no team currently has write access to it** — e.g. `@ochafik` (a `mcp-apps-sdk` member, admin on `ext-apps`) has `push: false` there, which blocks shipping the lazy-auth example server PR.

This adds the repo alongside its sibling `example-remote-client`, mirroring the team grants used for `ext-apps` (the apps surface these example servers belong to):

```ts
{
  repository: 'example-remote-server',
  teams: [
    { team: 'core-maintainers', permission: 'push' },
    { team: 'moderators', permission: 'maintain' },
    { team: 'mcp-apps-wg', permission: 'push' },
    { team: 'mcp-apps-sdk', permission: 'admin' },
  ],
}
```

## Verification

- `prettier --check` passes on the file.
- All four referenced teams (`core-maintainers`, `moderators`, `mcp-apps-wg`, `mcp-apps-sdk`) are defined in `roles.ts`, so the `validate-config.ts` team-reference check passes.
- `example-remote-server` appears exactly once (no duplicate); `test-config.ts` uniqueness checks are unaffected.

## After merge

The Pulumi `deploy` workflow applies it to GitHub, restoring write access so the `example-remote-server` lazy-auth PR can be pushed to the upstream.

cc @localden — could you take a look / approve? (CODEOWNERS → `@modelcontextprotocol/core-maintainers`.)