### PR TITLE
Add maxisbey to typescript-sdk-collaborators

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -499,7 +499,7 @@ export const MEMBERS: readonly Member[] = [
     firstName: 'Max',
     lastName: 'Isbey',
     googleEmailPrefix: 'max',
-    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.PYTHON_SDK],
+    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.PYTHON_SDK, ROLE_IDS.TYPESCRIPT_SDK_COLLABORATORS],
   },
   {
     github: 'michaelneale',


### PR DESCRIPTION
Adds @maxisbey to the `typescript-sdk-collaborators` team (push access on typescript-sdk). He is already an org member (maintainers, python-sdk).

Validated with `npm run check` (format, validate, test — all passing).