### PR TITLE
Add felixweinberger and maxisbey as admins on access repo

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -381,6 +381,13 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'moderators', permission: 'maintain' },
     ],
   },
+  {
+    repository: 'access',
+    users: [
+      { username: 'felixweinberger', permission: 'admin' },
+      { username: 'maxisbey', permission: 'admin' },
+    ],
+  },
 ];
 
 // GitHub Projects V2 permissions are NOT managed by Pulumi - no support yet


### PR DESCRIPTION
Adds an entry for the `access` repo itself to `repoAccess.ts`, granting felixweinberger and maxisbey admin so we can manage PRs and settings here.

Note for reviewers: this brings the access repo under `RepositoryCollaborators` management for the first time — that resource is authoritative, so any teams or direct collaborators currently on the repo that aren't listed here would be removed on deploy (org owners and the lead/core-maintainers org-role grants are unaffected). The Pulumi preview workflow doesn't run on fork PRs, so worth a quick `pulumi preview` check before/at merge.

Validated locally with `npm run check` (format, validate-config, tests — all pass).