### PR TITLE
Add ddworken and OctavianGuzu as admins on python-sdk and typescript-sdk

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -213,6 +213,10 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'python-sdk', permission: 'admin' },
       { team: 'python-sdk-auth', permission: 'admin' },
     ],
+    users: [
+      { username: 'ddworken', permission: 'admin' },
+      { username: 'OctavianGuzu', permission: 'admin' },
+    ],
   },
   {
     repository: 'ruby-sdk',
@@ -232,6 +236,10 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
       { team: 'typescript-sdk', permission: 'admin' },
       { team: 'typescript-sdk-auth', permission: 'admin' },
       { team: 'typescript-sdk-collaborators', permission: 'push' },
+    ],
+    users: [
+      { username: 'ddworken', permission: 'admin' },
+      { username: 'OctavianGuzu', permission: 'admin' },
     ],
   },
   {


### PR DESCRIPTION
Grants admin access on the python-sdk and typescript-sdk repositories to David Dworken (@ddworken) and Octavian Guzu (@OctavianGuzu) so they can manage GitHub Security Advisories on those repositories as part of the SDK vulnerability disclosure process.