### PR TITLE
Update repoAccess for experimental-ext-tasks rename to ext-tasks

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -366,7 +366,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     ],
   },
   {
-    repository: 'experimental-ext-tasks',
+    repository: 'ext-tasks',
     teams: [
       { team: 'core-maintainers', permission: 'admin' },
       { team: 'moderators', permission: 'maintain' },


### PR DESCRIPTION
The repository was renamed from `experimental-ext-tasks` to `ext-tasks`. GitHub redirects GET requests on the old name, but the team-repo DELETE endpoint the Pulumi github provider uses returns 404 against the old name. This has been failing the Deploy workflow since June 9, blocking propagation of every merge since then.

After this lands, Deploy should succeed and the changes from #122 and #124 will propagate.

There is also a config-vs-reality drift on this repo: `lead-maintainers` has admin access on `ext-tasks` in GitHub but is not in this config. Once Deploy is pointed at the correct repo name, the `--refresh` step will reconcile that. If `lead-maintainers` should keep access, a follow-up PR can add it to the config.