### PR TITLE
ci: temp state delete for renamed experimental-ext-tasks repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,9 @@ jobs:
           echo "$PULUMI_PASSPHRASE" > passphrase.prod.txt
           export PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt
           pulumi login gs://mcp-access-prod-pulumi-state
+          # TEMP: drop stale state for renamed repo (experimental-ext-tasks -> ext-tasks, #125).
+          # Delete-on-up 404s because the old repo name is gone. Remove after one successful deploy.
+          pulumi state delete 'urn:pulumi:prod::mcp-access::github:index/repositoryCollaborators:RepositoryCollaborators::repo-experimental-ext-tasks' --stack prod --yes || true
           pulumi config set discord:guildId "$DISCORD_GUILD_ID" --stack prod
           pulumi config set discord:botToken "$DISCORD_BOT_TOKEN" --secret --stack prod
           pulumi config set githubBillingEmail "$ORG_BILLING_EMAIL" --secret --stack prod


### PR DESCRIPTION
Deploys have been failing since #125 renamed `experimental-ext-tasks` → `ext-tasks`.

Pulumi state still holds the old `RepositoryCollaborators::repo-experimental-ext-tasks` resource. The first `pulumi up` in `make up` (which runs **before** refresh, by design — see Makefile comment re: dynamic providers) tries to delete it and gets a 404 because the repo no longer exists under that name:

```
DELETE .../repos/modelcontextprotocol/experimental-ext-tasks: 404 Not Found
deleting urn:pulumi:prod::mcp-access::github:index/repositoryCollaborators:RepositoryCollaborators::repo-experimental-ext-tasks: 1 error occurred
```

This blocks every deploy, including the `up --refresh` step that would reconcile other drift (e.g. team memberships removed manually in the GitHub UI).

**Fix:** drop the stale resource from state explicitly before `make up`. `|| true` keeps it idempotent so subsequent runs no-op once the entry is gone.

**Follow-up:** remove this line after one successful deploy on `main`. Longer-term, repo renames in `repoAccess.ts` should use Pulumi `aliases` so the resource is renamed in state instead of delete+create.