### PR TITLE
Give inspector-maintainers admin access on inspector repo

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -75,7 +75,7 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
   {
     repository: 'inspector',
     teams: [
-      { team: 'inspector-maintainers', permission: 'push' },
+      { team: 'inspector-maintainers', permission: 'admin' },
       { team: 'auth-maintainers', permission: 'push' },
       { team: 'core-maintainers', permission: 'maintain' },
       { team: 'csharp-sdk', permission: 'push' },


### PR DESCRIPTION
## Summary

Elevates the `inspector-maintainers` team from `push` to `admin` on the `inspector` repository.

This brings the Inspector maintainers to parity with the SDK teams (e.g. `go-sdk`, `python-sdk`, `typescript-sdk`) and the `reference-servers-maintainers` team, all of which hold `admin` on the repositories they own.

## Change

`src/config/repoAccess.ts`, `inspector` repo entry:

```diff
-      { team: 'inspector-maintainers', permission: 'push' },
+      { team: 'inspector-maintainers', permission: 'admin' },
```

## Validation

`npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)