### PR TITLE
chore: add name and email prefix for pederhp

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -643,6 +643,9 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'pederhp',
     discord: '166255967665651713',
+    firstName: 'Peder Holdgaard',
+    lastName: 'Pedersen',
+    googleEmailPrefix: 'pederhp',
     memberOf: [
       ROLE_IDS.COMMUNITY_MANAGERS,
       ROLE_IDS.MAINTAINERS,


### PR DESCRIPTION
Adds `firstName`, `lastName`, and `googleEmailPrefix` to my member entry in `src/config/users.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)