### PR TITLE
chore: add name and email prefix for myself

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -441,6 +441,9 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'Kludex',
     discord: '247021664624312322',
+    firstName: 'Marcelo',
+    lastName: 'Trylesinski',
+    googleEmailPrefix: 'marcelo',
     memberOf: [ROLE_IDS.PYTHON_SDK],
   },
   {


### PR DESCRIPTION
Adds my name and email prefix to get a `marcelo@modelcontextprotocol.io` account, same as #148.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.