### PR TITLE
chore: add name and email prefix for liady

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -462,6 +462,9 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'liady',
     discord: '383565833768665088',
+    firstName: 'Liad',
+    lastName: 'Yosef',
+    googleEmailPrefix: 'liad',
     memberOf: [ROLE_IDS.WORKING_GROUPS, ROLE_IDS.MCP_APPS_WG, ROLE_IDS.MCP_APPS_SDK],
   },
   {


### PR DESCRIPTION
Adds `firstName`, `lastName`, and `googleEmailPrefix` to my member entry in `src/config/users.ts`.