### PR TITLE
Grant felixweinberger admin on the conformance repo

### DIFF
--- a/src/config/repoAccess.ts
+++ b/src/config/repoAccess.ts
@@ -99,6 +99,10 @@ export const REPOSITORY_ACCESS: RepositoryAccess[] = [
     ],
   },
   {
+    repository: 'conformance',
+    users: [{ username: 'felixweinberger', permission: 'admin' }],
+  },
+  {
     repository: 'modelcontextprotocol',
     teams: [
       { team: 'auth-maintainers', permission: 'push' },


### PR DESCRIPTION
Brings the `conformance` repo under access management and grants @felixweinberger `admin` (currently `maintain` via a direct grant).

Context: the repo-level `default` ruleset on `conformance` only allows repository admins to bypass required status checks when merging, so `maintain` isn't enough to force-merge when checks are stuck.

Notes on safety of taking ownership of this repo's collaborators:
- Verified via the GitHub API that the only *direct* grant on the repo today is felixweinberger at `maintain` — this entry replaces it with `admin`.
- Team access visible on the repo (core-maintainers/lead-maintainers admin, security-managers pull) comes from org-level roles in `orgRoles.ts`, which per-repo collaborator management doesn't touch, so no teams are listed here (matching the `access` repo entry pattern).

`npm run check` passes (format, validate, 23/23 tests).