### PR TITLE
Skills Over MCP IG membership housekeeping

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -84,11 +84,7 @@ export const MEMBERS: readonly Member[] = [
     email: 'bob.dickinson@gmail.com',
     discord: '1175893001202045139',
     skipGoogleUserProvisioning: true,
-    memberOf: [
-      ROLE_IDS.MAINTAINERS,
-      ROLE_IDS.INSPECTOR_MAINTAINERS,
-      ROLE_IDS.REGISTRY_MAINTAINERS,
-    ],
+    memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.INSPECTOR_MAINTAINERS, ROLE_IDS.REGISTRY_MAINTAINERS],
   },
   {
     github: 'bolinfest',

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -24,6 +24,11 @@ export const MEMBERS: readonly Member[] = [
     googleEmailPrefix: 'aaronpk',
   },
   {
+    github: 'aditya-scio',
+    discord: '1196052678925631498',
+    memberOf: [ROLE_IDS.SKILLS_OVER_MCP_IG],
+  },
+  {
     github: 'ajribeiro',
     firstName: 'AJ',
     lastName: 'Ribeiro',
@@ -83,7 +88,6 @@ export const MEMBERS: readonly Member[] = [
       ROLE_IDS.MAINTAINERS,
       ROLE_IDS.INSPECTOR_MAINTAINERS,
       ROLE_IDS.REGISTRY_MAINTAINERS,
-      ROLE_IDS.SKILLS_OVER_MCP_IG,
     ],
   },
   {


### PR DESCRIPTION
Housekeeping pass on the Skills Over MCP Interest Group membership.

## Changes

- Add `aditya-scio` to `SKILLS_OVER_MCP_IG` (new member entry, with Discord ID for the synced role).
- Remove `SKILLS_OVER_MCP_IG` from `BobDickinson`. His other roles (`MAINTAINERS`, `INSPECTOR_MAINTAINERS`, `REGISTRY_MAINTAINERS`) are unchanged, so the member entry stays.

## Draft — pending confirmation

Left as a draft while we confirm who else still wants to be listed as active in the IG. Current roster after this change (13):

`aditya-scio`, `cliffhall`, `erain`, `JAORMX`, `kaxil`, `keithagroves`, `olaservo`, `pederhp`, `pja-ant`, `rdimitrov`, `sambhav`, `SamMorrowDrums`, `sunishsheth2009`

Any further removals will be pushed to this branch before it's marked ready for review.

## Validation

`npm run validate` and `npm run test` both pass (23/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)