### PR TITLE
Add Google Workspace-only account for Claude

### DIFF
--- a/src/config/roleIds.ts
+++ b/src/config/roleIds.ts
@@ -80,6 +80,11 @@ export const ROLE_IDS = {
   WG_IG_FACILITATORS: 'wg-ig-facilitators',
 
   // ===================
+  // Service Accounts (GWS user only, no platform roles)
+  // ===================
+  SERVICE_ACCOUNTS: 'service-accounts',
+
+  // ===================
   // Email Groups (Google only)
   // ===================
   ANTITRUST: 'antitrust',

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -423,6 +423,16 @@ export const ROLES: readonly Role[] = [
   },
 
   // ===================
+  // Service Accounts (GWS user only, no platform roles)
+  // ===================
+  {
+    id: ROLE_IDS.SERVICE_ACCOUNTS,
+    description: 'Service accounts with a Google Workspace user only (no GitHub or Discord)',
+    provisionUser: true,
+    // No github/discord/google config - exists solely to provision GWS user accounts
+  },
+
+  // ===================
   // Email Groups (Google only)
   // ===================
   {

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -872,4 +872,11 @@ export const MEMBERS: readonly Member[] = [
     email: 'davideramian@anthropic.com',
     memberOf: [ROLE_IDS.ANTITRUST],
   },
+  {
+    email: 'claude@modelcontextprotocol.io',
+    firstName: 'Claude',
+    lastName: 'AI',
+    googleEmailPrefix: 'claude',
+    memberOf: [ROLE_IDS.SERVICE_ACCOUNTS],
+  },
 ] as const;


### PR DESCRIPTION
## Summary
Provisions a Google Workspace account `claude@modelcontextprotocol.io` for Claude, who has no GitHub or Discord handle. Since every existing `provisionUser` role is a maintainer/WG role tied to those platforms (and validation rejects provisioning fields on members outside such roles), this adds a `service-accounts` role with no platform configs that exists solely to grant GWS user-provisioning eligibility.

The member entry sets `email` to the provisioned address because the config tests require every member to have at least one of github/email/discord as an identifier.

## Test plan
`npm run check` passes (prettier, validate-config, test-config 23/23). Local `pulumi preview` was blocked on expired gcloud credentials — relying on this PR's preview workflow to confirm the plan shows exactly one new `gws-user-claude` user and no group memberships.