### PR TITLE
chore: opt BobDickinson into Google Workspace provisioning

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -83,7 +83,9 @@ export const MEMBERS: readonly Member[] = [
     github: 'BobDickinson',
     email: 'bob.dickinson@gmail.com',
     discord: '1175893001202045139',
-    skipGoogleUserProvisioning: true,
+    firstName: 'Bob',
+    lastName: 'Dickinson',
+    googleEmailPrefix: 'bob.dickinson',
     memberOf: [ROLE_IDS.MAINTAINERS, ROLE_IDS.INSPECTOR_MAINTAINERS, ROLE_IDS.REGISTRY_MAINTAINERS],
   },
   {


### PR DESCRIPTION
## Summary
- Remove `skipGoogleUserProvisioning` from BobDickinson's entry
- Add `firstName`, `lastName`, and `googleEmailPrefix` to opt into a `bob.dickinson@modelcontextprotocol.io` Google Workspace account

## Test plan
- [ ] Config validation passes
- [ ] Pulumi preview shows expected GWS user provisioning


Made with [Cursor](https://cursor.com)