### PR TITLE
chore: add Matt Carey Google Workspace details

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -551,6 +551,9 @@ export const MEMBERS: readonly Member[] = [
   {
     github: 'mattzcarey',
     discord: '224878268275359744',
+    firstName: 'Matt',
+    lastName: 'Carey',
+    googleEmailPrefix: 'matt',
     memberOf: [ROLE_IDS.TYPESCRIPT_SDK, ROLE_IDS.TOOL_ANNOTATIONS_IG, ROLE_IDS.WG_IG_FACILITATORS],
   },
   {


### PR DESCRIPTION
## Summary
- add Matt Carey’s name and Google email prefix to the `mattzcarey` member entry
- opt into provisioning `matt@modelcontextprotocol.io`

## Validation
- `npm run check` (23 tests passed)