### PR TITLE
Removing Roman from PHP

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -748,10 +748,6 @@ export const MEMBERS: readonly Member[] = [
     memberOf: [ROLE_IDS.REGISTRY_COLLABORATORS],
   },
   {
-    github: 'pronskiy',
-    memberOf: [ROLE_IDS.PHP_SDK],
-  },
-  {
     github: 'pwwpche',
     discord: '1226238847013228604',
     memberOf: [],


### PR DESCRIPTION
Roman is leaving JetBrains and The PHP Foundation.

Thanks @pronskiy for kicking this off and bringing people together & all the best for the next endeavor. :pray: 
