### PR TITLE
Add Discord IDs and names for Filesystems WG members

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -197,6 +197,9 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'DanielTemesgen',
+    discord: '1537229954272600064',
+    firstName: 'Daniel',
+    lastName: 'Temesgen',
     memberOf: [ROLE_IDS.FILESYSTEMS_WG],
   },
   {
@@ -594,6 +597,9 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'michaelcheah',
+    discord: '1547217405837840415',
+    firstName: 'Michael',
+    lastName: 'Cheah',
     memberOf: [ROLE_IDS.FILESYSTEMS_WG],
   },
   {


### PR DESCRIPTION
## Before/After
Currently, the Filesystems Working Group has no access modeling in this repo. Its charter merged as modelcontextprotocol/modelcontextprotocol#3282 on 2026-09-08.

## How
This stacks on #171. The first three commits are #171 unchanged. Commit 0b66d99 adds the Discord identifiers on top.

- `src/config/roles.ts`: one role entry following the existing WG pattern, GitHub team parented to `ROLE_IDS.WORKING_GROUPS`, Discord role `filesystems working group (synced)`.                                                                                  
- `src/config/users.ts`: `ROLE_IDS.FILESYSTEMS_WG` added to the existing `sambhav` and `olaservo` entries, plus new entries for `DanielTemesgen` and `michaelcheah`.
- `src/config/users.ts`: `discord`, `firstName` and `lastName` set on the `DanielTemesgen` and `michaelcheah` entries, so the synced Discord role resolves to both accounts.

## Notes
**Note** Merge #171 first. This branch then reduces to commit 0b66d99.