### PR TITLE
Add Discord IDs and names for Filesystems WG members

### DIFF
--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -197,6 +197,9 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'DanielTemesgen',
+    discord: '1537229954272600064',
+    firstName: 'Daniel',
+    lastName: 'Temesgen',
     memberOf: [ROLE_IDS.FILESYSTEMS_WG],
   },
   {
@@ -595,6 +598,9 @@ export const MEMBERS: readonly Member[] = [
   },
   {
     github: 'michaelcheah',
+    discord: '1547217405837840415',
+    firstName: 'Michael',
+    lastName: 'Cheah',
     memberOf: [ROLE_IDS.FILESYSTEMS_WG],
   },
   {


### PR DESCRIPTION
Follow up to https://github.com/modelcontextprotocol/access/pull/171.